### PR TITLE
Use project_type in ios_build_and_test job

### DIFF
--- a/src/jobs/ios_build_and_test.yml
+++ b/src/jobs/ios_build_and_test.yml
@@ -79,6 +79,7 @@ steps:
       device: <<parameters.device>>
       build_configuration: <<parameters.build_configuration>>
       scheme: <<parameters.scheme>>
+      project_type: <<parameters.project_type>>
   - detox_test:
       configuration: <<parameters.detox_configuration>>
       loglevel: <<parameters.detox_loglevel>>


### PR DESCRIPTION
# Summary

It just uses `project_type` param that was missing in `ios_build_and_test` job

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |
