### PR TITLE
adding multiple templates for github issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: "Bug report"
+about: Create a report to help improve the project
+labels: bug
+
+---
+
+### Orb version
+
+<!---
+  e.g., 1.0.0
+  find this information in your config.yml file;
+  if the version is @volatile, check the top of your CircleCI-generated,
+  expanded configuration file, viewable from the "Configuration" tab of
+  any job page, for the orb's specific semantic version number
+-->
+
+### What happened
+
+<!---
+  please include any relevant links to CircleCI workflows or jobs
+  where you saw this behavior
+-->
+
+### Expected behavior
+
+<!--- what should happen, ideally? -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: "Feature request"
+about: Suggest an idea that will improve the project
+labels: enhancement
+
+---
+
+## What would you like to be added
+
+<!---
+  please describe the idea you have and the problem you are trying to solve
+-->
+
+## Why is this needed
+
+<!---
+  please explain why is this feature needed and how it improves the project
+-->


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Existing single GitHub template for issues is planned to be deprecated in the future and Github itself recommends updating the repo to new issue template workflow.

<img width="1002" alt="Screenshot 2019-10-10 10 19 26" src="https://user-images.githubusercontent.com/3473617/66555982-c74a7480-eb4f-11e9-89d9-65fb08226bc3.png">

This PR:
* adds issue template for bug report with proper label
* adds issue template for feature request with proper label

The library and the main code itself is not impacted whatsoever. 

## Test Plan

N/A

### What's required for testing (prerequisites)?

N/A

### What are the steps to reproduce (after prerequisites)?

Unfortunately, it cannot be tested from a branch, only once the changes are merged into _master_.
Clicking "New issue" button opens issue template chooser.

## Compatibility

N/A

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
