### PR TITLE
fix: remove haxm the lack hardware acceleration support causes a crash

### DIFF
--- a/src/commands/setup_macos_executor.yml
+++ b/src/commands/setup_macos_executor.yml
@@ -24,7 +24,6 @@ steps:
         HOMEBREW_NO_AUTO_UPDATE=1 brew install node@8 >/dev/null
         HOMEBREW_NO_AUTO_UPDATE=1 brew install applesimutils >/dev/null
         HOMEBREW_NO_AUTO_UPDATE=1 brew cask install android-sdk >/dev/null
-        HOMEBREW_NO_AUTO_UPDATE=1 brew cask install intel-haxm >/dev/null
         touch .watchmanconfig
         node -v
 


### PR DESCRIPTION
fixes #3 

# Summary
When working with this orb in a CIrcleCI environment I ran in to the following error: 

```
Error: Failure while executing; `/usr/bin/sudo -E -- env PATH=/usr/local/bin:/usr/local/sbin:/usr/local/Homebrew/Library/Homebrew/shims/scm:/usr/bin:/bin:/usr/sbin:/sbin /usr/local/Caskroom/intel-haxm/7.3.2/silent_install.sh` exited with 1. Here's the output:
Silent installation failed, please see /private/tmp/haxm_silent_run.log for details!
```
It turned out that the installation of haxm errors when there is no support for hardware acceleration. My solution was to remove the line where haxm gets installed. Hardware acceleration speeds up the Android simulator but it is not strictly necessary. 

## Test Plan

I forked the orb and made a new release in another namespace to validate that removing haxm solves the issue. 

### What's required for testing (prerequisites)?
Re-pack the orb after making the changes

### What are the steps to reproduce (after prerequisites)?
Run the ios_build_and_test job :)

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklis

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
