### PR TITLE
update gradle cache keys to match on save and restore

### DIFF
--- a/src/commands/android_build.yml
+++ b/src/commands/android_build.yml
@@ -49,13 +49,13 @@ steps:
       name: Saving Gradle wrapper cache
       paths:
         - ~/.gradle/wrapper/
-      key: gradle-wrapper-{{ checksum "<<parameters.project_path>>/gradle/wrapper/gradle-wrapper.properties" }}
+      key: gradle-wrapper-{{ arch }}-{{ checksum "<<parameters.project_path>>/gradle/wrapper/gradle-wrapper.properties" }}-{{ .Environment.CACHE_VERSION }}
 
   - save_cache:
       name: Saving Gradle home cache
       paths:
         - ~/.gradle/caches/
-      key: gradle-home-cache-{{ checksum "~/.tmp/checksumfiles/build.gradle" }}-{{ checksum "~/.tmp/checksumfiles/settings.gradle" }}
+      key: gradle-home-cache-{{ arch }}-{{ checksum "~/.tmp/checksumfiles/build.gradle" }}-{{ checksum "~/.tmp/checksumfiles/settings.gradle" }}-{{ .Environment.CACHE_VERSION }}
 
   - run:
       name: Build Android APK


### PR DESCRIPTION
# Summary

Hi, I've started using this orb to automate mobile app testing. Thanks for your work! :smiley_cat: 

I'm still trying to get the orb to work, but meanwhile here's a quick and easy pull-request to contribute back, which just is a minor fix for the Android build gradle cache keys, such that the saved keys match the restored keys.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |         |
| Android |    ✅     |

## Checklist


- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
