### PR TITLE
remove FBSimulatorControl

### DIFF
--- a/src/commands/setup_macos_executor.yml
+++ b/src/commands/setup_macos_executor.yml
@@ -27,19 +27,6 @@ steps:
         touch .watchmanconfig
         node -v
 
-  # Ideally we would do this using Homebrew above, but we need a specific revision due to this issue:
-  # https://github.com/facebook/FBSimulatorControl/pull/508
-  - run:
-      name: Install FBSimulatorControl
-      command: |
-        cd /tmp
-        git clone https://github.com/facebook/FBSimulatorControl.git FBSimulatorControl
-        cd FBSimulatorControl
-        git checkout 778f9825cb82aabac82f1ed474f1dba1e0276211
-        ./build.sh fbsimctl build >/dev/null
-        cp -r build/Build/Products/Debug/* /usr/local/bin
-        which fbsimctl
-
   - save_cache:
       paths:
         - /usr/local/Homebrew


### PR DESCRIPTION
FBSimulatorControl is no longer needed by detox and there is no need to install it. Moreover the specified commit does no longer work with the latest macos executor on circleci

# Summary
fixes https://github.com/react-native-community/react-native-circleci-orb/issues/23
