### PR TITLE
Add iOS build job and example of it

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,17 @@ workflows:
           requires:
             - build_android_release
 
+
+      # Build the iOS app in release mode and do not run tests
+      - rn/ios_build:
+          name: build_ios_release
+          project_path: ios/Example.xcodeproj
+          device: "iPhone X"
+          build_configuration: Release
+          scheme: Example
+          requires:
+            - analyse_js
+
       # Build and test the iOS app in release mode
       - rn/ios_build_and_test:
           project_path: "ios/Example.xcodeproj"

--- a/src/examples/full.yml
+++ b/src/examples/full.yml
@@ -84,6 +84,16 @@ usage:
             requires:
               - build_android_release
 
+        # Build the iOS app in release mode and do not run tests
+        - rn/ios_build:
+            name: build_ios_release
+            project_path: ios/Example.xcodeproj
+            device: "iPhone X"
+            build_configuration: Release
+            scheme: Example
+            requires:
+              - analyse_js
+
         # Build and test the iOS app in release mode
         - rn/ios_build_and_test:
             project_path: "ios/Example.xcodeproj"

--- a/src/examples/ios.yml
+++ b/src/examples/ios.yml
@@ -58,6 +58,16 @@ usage:
             requires:
               - checkout_code
 
+        # Build the iOS app in release mode and do not run tests
+        - rn/ios_build:
+            name: build_ios_release
+            project_path: ios/Example.xcodeproj
+            device: "iPhone X"
+            build_configuration: Release
+            scheme: Example
+            requires:
+              - analyse_js
+
         # Build and test the iOS app in release mode
         - rn/ios_build_and_test:
             project_path: "ios/Example.xcodeproj"

--- a/src/jobs/ios_build.yml
+++ b/src/jobs/ios_build.yml
@@ -1,0 +1,70 @@
+description: Builds the iOS app at the given path with the given build scheme
+
+executor: macos
+
+parameters:
+  # For this job
+  checkout:
+    description: Boolean for whether or not to checkout as a first step. Default is false.
+    type: boolean
+    default: false
+  attach_workspace:
+    description: Boolean for whether or not to attach to an existing workspace. Default is true.
+    type: boolean
+    default: true
+  workspace_root:
+    description: Workspace root path that is either an absolute path or a path relative to the working directory. Defaults to '.' (the working directory).
+    type: string
+    default: .
+  start_metro:
+    description: If we should start the Metro packager in the background for this job.
+    type: boolean
+    default: false
+  # For the iOS build command
+  project_type:
+    description: If the iOS app is built using a project file (*.xcodeproj) or a workspace.
+    type: enum
+    enum: ["project", "workspace"]
+    default: "project"
+  project_path:
+    description: The path to the Xcode project (*.xcodeproj) or the Xcode workspace (*.xcworkspace) that you want to build, relative to the root of the repository.
+    type: string
+  build_configuration:
+    description: The build configuration to use. This is normally either "Debug" or "Release" but you may have custom build configuration configured for your app.
+    type: string
+    default: "Debug"
+  derived_data_path:
+    description: The path to the directory to place the derived data, relative to the root of the repository.
+    type: string
+    default: "ios/build"
+  device:
+    description: The type of device you want to build for.
+    type: string
+    default: "iPhone X"
+  scheme:
+    description: The scheme to use.
+    type: string
+
+steps:
+  - when:
+      condition: <<parameters.checkout>>
+      steps:
+        - checkout
+  - when:
+      condition: <<parameters.attach_workspace>>
+      steps:
+        - attach_workspace:
+            at: <<parameters.workspace_root>>
+  - setup_macos_executor
+  - yarn_install
+  - when:
+      condition: <<parameters.start_metro>>
+      steps:
+        - metro_start
+  - ios_build:
+      project_path: <<parameters.project_path>>
+      derived_data_path: <<parameters.derived_data_path>>
+      device: <<parameters.device>>
+      build_configuration: <<parameters.build_configuration>>
+      scheme: <<parameters.scheme>>
+      project_type: <<parameters.project_type>>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

* Allow to just run the iOS Build without having the Detox lib in the project. Closes #29 
* How did you implement the solution?
   I copied the `ios_build_and_test.yml` file and removed everything related to Detox.
* What areas of the library does it impact?
  It adds a new job and do not change any existing job. 

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Command used in the project:

   Build the iOS app in release mode
```
      - rn/ios_build:
          name: build_ios_release
          project_path: ios/OlistApp.xcodeproj
          device: "iPhone X"
          build_configuration: Release
          scheme: OlistApp
          requires:
            - analyse_js
```
![Run iOS build command](https://user-images.githubusercontent.com/24610813/71702324-814b2880-2dad-11ea-9836-775f64e8f91c.png)

Running jobs: 
![Running jobs](https://user-images.githubusercontent.com/24610813/71702445-557c7280-2dae-11ea-857f-e67557fc746c.png)

Some job configuration:
![Job Configuration](https://user-images.githubusercontent.com/24610813/71702484-7775f500-2dae-11ea-84df-e444210fde5f.png)

Result of build_ios job: 
![Result of build_ios job](https://user-images.githubusercontent.com/24610813/71702581-04b94980-2daf-11ea-800e-436a256a89fc.png)

Finished jobs:
![Finished jobs](https://user-images.githubusercontent.com/24610813/71702590-139ffc00-2daf-11ea-9154-6bc63208e3a5.png)

-------
Commands used to deploy this project in a testing Orb (I was not able to test it locally, so I used my Orb in my current project to test this logic and its result are on the Screenshots above):
1) `sh scripts/pack.sh`
2) `circleci orb publish packed-orb.yml react-native-circleci-orb/react-native-circleci-orb@1.4.3` 
3) Orb is deployed to: `https://circleci.com/orbs/registry/orb/react-native-circleci-orb/react-native-circleci-orb`



### What's required for testing (prerequisites)?
MacOS plan on CircleCi

### What are the steps to reproduce (after prerequisites)?
 - rn/ios_build:
          name: build_ios_release
          project_path: ios/OlistApp.xcodeproj
          device: "iPhone X"
          build_configuration: Release
          scheme: OlistApp
          requires:
            - analyse_js

## Compatibility (Android similar job already exists:)

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅      | 


## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a simulator
- [X] I added the documentation in `README.md`
- [x] I mentioned this change in `CHANGELOG.md` (I added the `feat: ` tag)
- [ ] I updated the typed files (TS and Flow)
- [X] I added a sample use of the API in the example project (`example/App.js`)
