### PR TITLE
Add more config parameters for android_build

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,10 @@ workflows:
       - rn/android_build:
           name: build_android_release
           project_path: "android"
-          build_type: release
+          assemble_build_type: assembleRelease
+          assemble_test_type: assembleAndroidTest
+          test_build_type: release
+          max_workers: 2
           requires:
             - analyse_js
       - rn/android_test:

--- a/src/commands/android_build.yml
+++ b/src/commands/android_build.yml
@@ -1,12 +1,24 @@
-description: Builds the Android app at the given path with the given build types. This should be run only after installing dependencies. 
+description: Builds the Android app at the given path with the given build types. This should be run only after installing dependencies.
 
 parameters:
   project_path:
     description: The path to the root of the Android project you want to build, relative to the root of the repository.
     type: string
     default: "./android"
-  build_type:
-    description: The build type to build. This is normally either "debug" or "release" but you may have custom build types configured for your app.
+  max_workers:
+    description: The number of workers to use for a build
+    type: integer
+    default: 2
+  assemble_build_type:
+    description: The build variant to build. This is normally either "assembleDebug" or "assembleRelease" but you may have custom build variants that you can specify here.
+    type: string
+    default: "assembleDebug"
+  assemble_test_type:
+    description: The test build varinat to build. This is normally "assembleAndroidTest" but you may have custom build variantes that you can specify here.
+    type: string
+    default: "assembleAndroidTest"
+  test_build_type:
+    description: The test build type to build. This is normally "debug" or "release".
     type: string
     default: "debug"
 
@@ -59,7 +71,7 @@ steps:
 
   - run:
       name: Build Android APK
-      command: "cd <<parameters.project_path>> && chmod +x gradlew && ./gradlew --build-cache --max-workers 2 --continue assemble<<parameters.build_type>> assembleAndroidTest -DtestBuildType=<<parameters.build_type>> --stacktrace"
+      command: "cd <<parameters.project_path>> && chmod +x gradlew && ./gradlew --build-cache --max-workers <<parameters.max_workers>> --continue <<parameters.assemble_build_type>> <<parameters.assemble_test_type>> -DtestBuildType=<<parameters.test_build_type>> --stacktrace"
 
   - run:
       name: Collecting Gradle Build caches for saving

--- a/src/commands/android_build.yml
+++ b/src/commands/android_build.yml
@@ -14,7 +14,7 @@ parameters:
     type: string
     default: "assembleDebug"
   assemble_test_type:
-    description: The test build varinat to build. This is normally "assembleAndroidTest" but you may have custom build variantes that you can specify here.
+    description: The test build variant to build. This is normally "assembleAndroidTest" but you may have custom build variants that you can specify here.
     type: string
     default: "assembleAndroidTest"
   test_build_type:

--- a/src/jobs/android_build.yml
+++ b/src/jobs/android_build.yml
@@ -38,7 +38,7 @@ parameters:
     type: string
     default: "assembleDebug"
   assemble_test_type:
-    description: The test build varinat to build. This is normally "assembleAndroidTest" but you may have custom build variantes that you can specify here.
+    description: The test build variant to build. This is normally "assembleAndroidTest" but you may have custom build variants that you can specify here.
     type: string
     default: "assembleAndroidTest"
   test_build_type:

--- a/src/jobs/android_build.yml
+++ b/src/jobs/android_build.yml
@@ -29,8 +29,20 @@ parameters:
     description: The path to the root of the Android project you want to build, relative to the root of the repository.
     type: string
     default: "./android"
-  build_type:
-    description: The build type to build. This is normally either "debug" or "release" but you may have custom build types configured for your app.
+  max_workers:
+    description: The number of workers to use for a build
+    type: integer
+    default: 2
+  assemble_build_type:
+    description: The build variant to build. This is normally either "assembleDebug" or "assembleRelease" but you may have custom build variants that you can specify here.
+    type: string
+    default: "assembleDebug"
+  assemble_test_type:
+    description: The test build varinat to build. This is normally "assembleAndroidTest" but you may have custom build variantes that you can specify here.
+    type: string
+    default: "assembleAndroidTest"
+  test_build_type:
+    description: The test build type to build. This is normally "debug" or "release".
     type: string
     default: "debug"
   on_after_initialize:
@@ -57,7 +69,10 @@ steps:
             command: <<parameters.on_after_initialize>>
   - android_build:
       project_path: <<parameters.project_path>>
-      build_type: <<parameters.build_type>>
+      assemble_build_type: <<parameters.assemble_build_type>>
+      assemble_test_type: <<parameters.assemble_test_type>>
+      test_build_type: <<parameters.test_build_type>>
+      max_workers: <<parameters.max_workers>>
   - when:
       condition: <<parameters.persist_to_workspace>>
       steps:


### PR DESCRIPTION
# Summary

Add more parameters to the android_build command. This allows us to be more explicit with our build variants and it terms will save minutes on circleCI by only specifying the build variantes that we really needs

fixes #33

**This is a breaking change!**
We need to specify the following parameters
```
  max_workers:
    description: The number of workers to use for a build
    type: integer
    default: 2
  assemble_build_type:
    description: The build variant to build. This is normally either "assembleDebug" or "assembleRelease" but you may have custom build variants that you can specify here.
    type: string
    default: "assembleDebug"
  assemble_test_type:
    description: The test build variant to build. This is normally "assembleAndroidTest" but you may have custom build variants that you can specify here.
    type: string
    default: "assembleAndroidTest"
  test_build_type:
    description: The test build type to build. This is normally "debug" or "release".
    type: string
    default: "debug"
```

where previously we only had build_type. 

If we don't specify any parameters then the config should have the old behavior.

I also updated the android_build job with the new syntax

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
