### PR TITLE
Fix/node version macos

### DIFF
--- a/src/commands/setup_macos_executor.yml
+++ b/src/commands/setup_macos_executor.yml
@@ -27,7 +27,9 @@ steps:
       command: |
         HOMEBREW_NO_AUTO_UPDATE=1 brew tap wix/brew >/dev/null
         HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/cask >/dev/null
+        HOMEBREW_NO_AUTO_UPDATE=1 brew unlink node >/dev/null
         HOMEBREW_NO_AUTO_UPDATE=1 brew install node@<<parameters.node_version>> >/dev/null
+        HOMEBREW_NO_AUTO_UPDATE=1 brew link --overwrite node@<<parameters.node_version>> --force >/dev/null
         HOMEBREW_NO_AUTO_UPDATE=1 brew install applesimutils >/dev/null
         HOMEBREW_NO_AUTO_UPDATE=1 brew cask install android-sdk >/dev/null
         touch .watchmanconfig

--- a/src/commands/setup_macos_executor.yml
+++ b/src/commands/setup_macos_executor.yml
@@ -22,14 +22,25 @@ steps:
       key: |
         brew-cache-{{ arch }}-{{ .Environment.CACHE_VERSION }}
 
+  - run: 
+      name: Install node@<<parameters.node_version>>
+      command: |
+          set +e         
+          touch $BASH_ENV    
+          curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.5/install.sh | bash
+          echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
+          echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
+          echo nvm install <<parameters.node_version>> >> $BASH_ENV
+          echo nvm alias default <<parameters.node_version>> >> $BASH_ENV
+  - run:
+      name: Verify node version
+      command: node --version
+  
   - run:
       name: Configure Detox Environment
       command: |
         HOMEBREW_NO_AUTO_UPDATE=1 brew tap wix/brew >/dev/null
         HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/cask >/dev/null
-        HOMEBREW_NO_AUTO_UPDATE=1 brew unlink node >/dev/null
-        HOMEBREW_NO_AUTO_UPDATE=1 brew install node@<<parameters.node_version>> >/dev/null
-        HOMEBREW_NO_AUTO_UPDATE=1 brew link --overwrite node@<<parameters.node_version>> --force >/dev/null
         HOMEBREW_NO_AUTO_UPDATE=1 brew install applesimutils >/dev/null
         HOMEBREW_NO_AUTO_UPDATE=1 brew cask install android-sdk >/dev/null
         touch .watchmanconfig


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
* Fix node version node not being updated on CircleCi.
Related to #39  and #38 

## Test Plan
**DEFAULT NODE:**
```
- rn/ios_build:
         name: build_ios_debug
         project_path: ios/Example.xcworkspace
         project_type: workspace
         device: "iPhone X"
         build_configuration: Debug
         scheme: Example
         requires:
           - analyse_js

```
<img width="1320" alt="Screen Shot 2020-02-03 at 02 03 17" src="https://user-images.githubusercontent.com/24610813/73626917-69bfc380-4629-11ea-842f-28607c7802f8.png">

**NODE 12.14.1**
```
- rn/ios_build:
         name: build_ios_debug
         node_version: "12.14.1"
         project_path: ios/Example.xcworkspace
         project_type: workspace
         device: "iPhone X"
         build_configuration: Debug
         scheme: Example
         requires:
           - analyse_js
```
<img width="1317" alt="Screen Shot 2020-02-03 at 01 46 25" src="https://user-images.githubusercontent.com/24610813/73626634-6e37ac80-4628-11ea-9fb0-ef1fd87c29ab.png">

**NODE 13.7.0**
```
- rn/ios_build:
         name: build_ios_debug
         node_version: "13.7.0"
         project_path: ios/Example.xcworkspace
         project_type: workspace
         device: "iPhone X"
         build_configuration: Debug
         scheme: Example
         requires:
           - analyse_js
```
<img width="1328" alt="Screen Shot 2020-02-03 at 02 57 36" src="https://user-images.githubusercontent.com/24610813/73629166-0cc80b80-4631-11ea-9a36-55896e51c49e.png">

### What's required for testing (prerequisites)?
MacOs Plan

### What are the steps to reproduce (after prerequisites)?
Testing Orb:  [roni-castro/react-native-circleci-orb@2.3.7](https://circleci.com/orbs/registry/orb/roni-castro/react-native-circleci-orb)
**Observation**: The version 2.3.7 of the testing Orb I have also updated the default xcode version from `10.1.0` to `11.0.0` and added a parameter on `ios_build` and `ios_build_and_test` by adding `xcode_version: '10.1.0'`, but on the tests I used this parameter with the value equal to `10.1.0` (the same on the `macos.yml` of this official repo), so I think this change is not affecting the tests above.
<img width="676" alt="Screen Shot 2020-02-03 at 02 13 01" src="https://user-images.githubusercontent.com/24610813/73627279-beb00980-462a-11ea-8295-6811faf069be.png">


## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [X] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)

