### PR TITLE
fix mac node install

### DIFF
--- a/src/commands/setup_macos_executor.yml
+++ b/src/commands/setup_macos_executor.yml
@@ -24,14 +24,14 @@ steps:
 
   - run: 
       name: Install node@<<parameters.node_version>>
+      # after `curl`, bashrc contains the script to load nvm, we need to source it to use it
       command: |
-          set +e         
-          touch $BASH_ENV    
-          curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.5/install.sh | bash
-          echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
-          echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
-          echo nvm install <<parameters.node_version>> >> $BASH_ENV
-          echo nvm alias default <<parameters.node_version>> >> $BASH_ENV
+        set +e
+        curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.35.3/install.sh | bash
+        source ~/.bashrc
+        command -v nvm
+        nvm install <<parameters.node_version>>
+        nvm alias default <<parameters.node_version>>
   - run:
       name: Verify node version
       command: node --version


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
fixes https://github.com/react-native-community/react-native-circleci-orb/issues/43

motivation: 

previously this was used to install node

```
echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
echo nvm install <<parameters.node_version>> >> $BASH_ENV
echo nvm alias default <<parameters.node_version>> >> $BASH_ENV
```

it ads `nvm install` to file at $BASH_ENV location. As described in https://linuxhint.com/bash-environment-variables/

> Value of this variable is expanded and used as the name of a startup file before a script is executed

so the `nvm install` script is executed for many (not all) commands user would type into terminal. This prints 

```v10.19.0 is already installed.
Now using node v10.19.0 (npm v6.13.4)
v10.19.0 is already installed.
```
over and over again into terminal. See for example yarn install step in [this circle job](https://circleci.com/gh/react-native-community/datetimepicker/465). This is

- annoying
- causes other software which captures and processes stdout to not work: see https://github.com/wix/AppleSimulatorUtils/issues/69



## Test Plan

I used `circleci config pack` to pack this orb and I'm using it with the proposed modifications in react-native-community/datetimepicker#144


### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |


