### PR TITLE
add pod install command

### DIFF
--- a/src/commands/ios_build.yml
+++ b/src/commands/ios_build.yml
@@ -1,10 +1,6 @@
 description: Builds the iOS app at the given path with the given build scheme and configuration. This should be run only after installing NPM dependencies.
 
 parameters:
-  pod_install_directory:
-    type: string
-    default: ""
-    description: The location of the "ios" directory for `pod install`
   project_type:
     description: If the iOS app is built using a project file (*.xcodeproj) or a workspace.
     type: enum
@@ -35,11 +31,6 @@ steps:
       keys:
         - ios-build-cache-{{ arch }}-{{ checksum "~/.tmp/checksumfiles/package.json" }}-{{ .Environment.CACHE_VERSION }}
 
-  - when:
-      condition: <<parameters.pod_install_directory>>
-      steps:
-        - pod_install:
-            pod_install_directory: <<parameters.pod_install_directory>>
   - run:
       name: Build iOS App
       command: "export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -<<parameters.project_type>> <<parameters.project_path>> -destination 'platform=iOS Simulator,name=<<parameters.device>>' -scheme <<parameters.scheme>> -parallelizeTargets -configuration <<parameters.build_configuration>> -derivedDataPath <<parameters.derived_data_path>>  -UseModernBuildSystem=YES | xcpretty -k"

--- a/src/commands/ios_build.yml
+++ b/src/commands/ios_build.yml
@@ -1,6 +1,10 @@
 description: Builds the iOS app at the given path with the given build scheme and configuration. This should be run only after installing NPM dependencies.
 
 parameters:
+  pod_install_directory:
+    type: string
+    default: ""
+    description: The location of the "ios" directory for `pod install`
   project_type:
     description: If the iOS app is built using a project file (*.xcodeproj) or a workspace.
     type: enum
@@ -31,6 +35,11 @@ steps:
       keys:
         - ios-build-cache-{{ arch }}-{{ checksum "~/.tmp/checksumfiles/package.json" }}-{{ .Environment.CACHE_VERSION }}
 
+  - when:
+      condition: <<parameters.pod_install_directory>>
+      steps:
+        - pod_install:
+            pod_install_directory: <<parameters.pod_install_directory>>
   - run:
       name: Build iOS App
       command: "export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -<<parameters.project_type>> <<parameters.project_path>> -destination 'platform=iOS Simulator,name=<<parameters.device>>' -scheme <<parameters.scheme>> -parallelizeTargets -configuration <<parameters.build_configuration>> -derivedDataPath <<parameters.derived_data_path>>  -UseModernBuildSystem=YES | xcpretty -k"

--- a/src/commands/pod_install.yml
+++ b/src/commands/pod_install.yml
@@ -7,6 +7,7 @@ description: install pods, use CircleCI cache to fetch CocoaPods specs
 parameters:
   pod_install_directory:
     type: string
+    default: "ios"
     description: The location of the "ios" directory
 steps:
   - run:

--- a/src/commands/pod_install.yml
+++ b/src/commands/pod_install.yml
@@ -1,0 +1,16 @@
+description: install pods, use CircleCI cache to fetch CocoaPods specs
+
+# note: do not use the --project-directory pod param because many example
+# projects in the rn community repos rely on pod install to be run from ios directory
+# instead cd into the folder and then back
+
+parameters:
+  pod_install_directory:
+    type: string
+    description: The location of the "ios" directory
+steps:
+  - run:
+      name: Install CocoaPods
+      command: |
+        curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
+        cd <<parameters.pod_install_directory>> && pod install && cd -

--- a/src/jobs/ios_build_and_test.yml
+++ b/src/jobs/ios_build_and_test.yml
@@ -20,11 +20,11 @@ parameters:
     description: If we should start the Metro packager in the background for this job.
     type: boolean
     default: false
-  # For the iOS build command
   pod_install_directory:
     type: string
     default: ""
     description: The location of the "ios" directory for `pod install`
+  # For the iOS build command
   project_type:
     description: If the iOS app is built using a project file (*.xcodeproj) or a workspace.
     type: enum
@@ -93,8 +93,12 @@ steps:
       condition: <<parameters.start_metro>>
       steps:
         - metro_start
+  - when:
+      condition: <<parameters.pod_install_directory>>
+      steps:
+        - pod_install:
+            pod_install_directory: <<parameters.pod_install_directory>>
   - ios_build:
-      pod_install_directory: <<parameters.pod_install_directory>>
       project_path: <<parameters.project_path>>
       derived_data_path: <<parameters.derived_data_path>>
       device: <<parameters.device>>

--- a/src/jobs/ios_build_and_test.yml
+++ b/src/jobs/ios_build_and_test.yml
@@ -21,6 +21,10 @@ parameters:
     type: boolean
     default: false
   # For the iOS build command
+  pod_install_directory:
+    type: string
+    default: ""
+    description: The location of the "ios" directory for `pod install`
   project_type:
     description: If the iOS app is built using a project file (*.xcodeproj) or a workspace.
     type: enum
@@ -62,7 +66,7 @@ parameters:
   node_version:
     description: The version of Node to use. This can be either a major version ("8"), a major and minor ("8.4"), or a fully qualified version ("8.4.1").
     type: string
-    default: '10'
+    default: "10"
 
 steps:
   - when:
@@ -75,9 +79,9 @@ steps:
         - attach_workspace:
             at: <<parameters.workspace_root>>
   - setup_macos_executor:
-        node_version: <<parameters.node_version>>
+      node_version: <<parameters.node_version>>
   - ios_simulator_start:
-        device: <<parameters.device>>
+      device: <<parameters.device>>
   - yarn_install
   - when:
       condition: <<parameters.on_after_initialize>>
@@ -90,6 +94,7 @@ steps:
       steps:
         - metro_start
   - ios_build:
+      pod_install_directory: <<parameters.pod_install_directory>>
       project_path: <<parameters.project_path>>
       derived_data_path: <<parameters.derived_data_path>>
       device: <<parameters.device>>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

motivation: since RN 0.60 pods are default and it feels like it makes sense to have them covered. It's a short command, but circle has a cache for pod specs they recommend to use and this way users get it the right way for free.



## Test Plan

I used `circleci config pack` to pack this orb and I'm using it with the proposed modifications in react-native-community/datetimepicker#144


### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |



