### PR TITLE
Adding new param to use an specific version of node when running `yarn_install`

### DIFF
--- a/src/commands/set_node_version.yml
+++ b/src/commands/set_node_version.yml
@@ -10,17 +10,13 @@ steps:
       name: Install node@<<parameters.node_version>>
       # after `curl`, bashrc contains the script to load nvm, we need to source it to use it
       command: |
-        set +e
-        curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.35.3/install.sh | bash
-        source ~/.bashrc
-        command -v nvm
-        nvm install <<parameters.node_version>>
-        nvm alias default <<parameters.node_version>>
-  - run:
-      name: Update node_version at bash
-      command: |
-        echo 'export PATH="$PATH:/usr/local/opt/node@<<parameters.node_version>>/bin:~/.yarn/bin:~/project/node_modules/.bin:~/project/example/node_modules/.bin"' >> $BASH_ENV
-        source $BASH_ENV
+        set +e         
+        touch $BASH_ENV    
+        curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.5/install.sh | bash
+        echo 'export NVM_DIR="$HOME/.nvm"' >> $BASH_ENV
+        echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
+        echo nvm install <<parameters.node_version>> >> $BASH_ENV
+        echo nvm alias default <<parameters.node_version>> >> $BASH_ENV
   - run:
       name: Verify node version
       command: node --version

--- a/src/commands/set_node_version.yml
+++ b/src/commands/set_node_version.yml
@@ -17,5 +17,10 @@ steps:
         nvm install <<parameters.node_version>>
         nvm alias default <<parameters.node_version>>
   - run:
+      name: Update node_version at bash
+      command: |
+        echo 'export PATH="$PATH:/usr/local/opt/node@<<parameters.node_version>>/bin:~/.yarn/bin:~/project/node_modules/.bin:~/project/example/node_modules/.bin"' >> $BASH_ENV
+        source $BASH_ENV
+  - run:
       name: Verify node version
       command: node --version

--- a/src/commands/set_node_version.yml
+++ b/src/commands/set_node_version.yml
@@ -1,0 +1,21 @@
+description: install a specific version of node using nvm
+
+parameters:
+  node_version:
+    description: The version of Node to use. This can be either a major version ("8"), a major and minor ("8.4"), or a fully qualified version ("8.4.1").
+    type: string
+    default: '10'
+steps:
+  - run: 
+      name: Install node@<<parameters.node_version>>
+      # after `curl`, bashrc contains the script to load nvm, we need to source it to use it
+      command: |
+        set +e
+        curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.35.3/install.sh | bash
+        source ~/.bashrc
+        command -v nvm
+        nvm install <<parameters.node_version>>
+        nvm alias default <<parameters.node_version>>
+  - run:
+      name: Verify node version
+      command: node --version

--- a/src/commands/setup_macos_executor.yml
+++ b/src/commands/setup_macos_executor.yml
@@ -24,7 +24,7 @@ steps:
 
   - run: 
       - set_node_version:
-        node_version: <<parameters.node_version>>
+          node_version: <<parameters.node_version>>
   - run:
       name: Configure Detox Environment
       command: |

--- a/src/commands/setup_macos_executor.yml
+++ b/src/commands/setup_macos_executor.yml
@@ -23,19 +23,8 @@ steps:
         brew-cache-{{ arch }}-{{ .Environment.CACHE_VERSION }}
 
   - run: 
-      name: Install node@<<parameters.node_version>>
-      # after `curl`, bashrc contains the script to load nvm, we need to source it to use it
-      command: |
-        set +e
-        curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.35.3/install.sh | bash
-        source ~/.bashrc
-        command -v nvm
-        nvm install <<parameters.node_version>>
-        nvm alias default <<parameters.node_version>>
-  - run:
-      name: Verify node version
-      command: node --version
-  
+      - set_node_version:
+        node_version: <<parameters.node_version>>
   - run:
       name: Configure Detox Environment
       command: |

--- a/src/commands/yarn_install.yml
+++ b/src/commands/yarn_install.yml
@@ -5,6 +5,10 @@ parameters:
     description: If you want a specific version, when you this command.
     type: boolean
     default: false
+  node_version:
+    description: The version of Node to use. This can be either a major version ("8"), a major and minor ("8.4"), or a fully qualified version ("8.4.1").
+    type: string
+    default: '10'
 
 steps:
   - when:

--- a/src/commands/yarn_install.yml
+++ b/src/commands/yarn_install.yml
@@ -15,8 +15,7 @@ steps:
       condition: <<parameters.force_node_version_install>>
       steps:
         - set_node_version:
-          node_version: <<parameters.node_version>>
-      
+            node_version: <<parameters.node_version>>
   - run:
       name: Create cache checksum file
       command: |

--- a/src/commands/yarn_install.yml
+++ b/src/commands/yarn_install.yml
@@ -1,6 +1,18 @@
 description: Install Javascript dependencies using Yarn. This command correctly configures the cache for any number of package.json and yarn.lock files.
 
+parameters:
+  force_node_version:
+    description: If you want a specific version, when you this command.
+    type: boolean
+    default: false
+
 steps:
+  - when:
+      condition: <<parameters.force_node_version_install>>
+      steps:
+        - set_node_version:
+          node_version: <<parameters.node_version>>
+      
   - run:
       name: Create cache checksum file
       command: |

--- a/src/commands/yarn_install.yml
+++ b/src/commands/yarn_install.yml
@@ -1,7 +1,7 @@
 description: Install Javascript dependencies using Yarn. This command correctly configures the cache for any number of package.json and yarn.lock files.
 
 parameters:
-  force_node_version:
+  force_node_version_install:
     description: If you want a specific version, when you this command.
     type: boolean
     default: false

--- a/src/jobs/android_build.yml
+++ b/src/jobs/android_build.yml
@@ -37,6 +37,10 @@ parameters:
     description: A custom command to run right after yarn install.
     type: string
     default: ""
+  force_node_version:
+    description: If you want a specific version of node when running yarn_install.
+    type: boolean
+    default: false
 
 steps:
   - when:
@@ -48,7 +52,8 @@ steps:
       steps:
         - attach_workspace:
             at: <<parameters.workspace_root>>
-  - yarn_install
+  - yarn_install:
+      force_node_version: <<parameters.force_node_version>>
   - when:
       condition: <<parameters.on_after_initialize>>
       steps:

--- a/src/jobs/android_build.yml
+++ b/src/jobs/android_build.yml
@@ -37,7 +37,7 @@ parameters:
     description: A custom command to run right after yarn install.
     type: string
     default: ""
-  force_node_version:
+  force_node_version_install:
     description: If you want a specific version of node when running yarn_install.
     type: boolean
     default: false
@@ -53,7 +53,7 @@ steps:
         - attach_workspace:
             at: <<parameters.workspace_root>>
   - yarn_install:
-      force_node_version: <<parameters.force_node_version>>
+      force_node_version_install: <<parameters.force_node_version_install>>
   - when:
       condition: <<parameters.on_after_initialize>>
       steps:

--- a/src/jobs/android_build.yml
+++ b/src/jobs/android_build.yml
@@ -41,6 +41,10 @@ parameters:
     description: If you want a specific version of node when running yarn_install.
     type: boolean
     default: false
+  node_version:
+    description: The version of Node to use. This can be either a major version ("8"), a major and minor ("8.4"), or a fully qualified version ("8.4.1").
+    type: string
+    default: '10'
 
 steps:
   - when:
@@ -54,6 +58,7 @@ steps:
             at: <<parameters.workspace_root>>
   - yarn_install:
       force_node_version_install: <<parameters.force_node_version_install>>
+      node_version: <<parameters.node_version>>
   - when:
       condition: <<parameters.on_after_initialize>>
       steps:

--- a/src/jobs/android_test.yml
+++ b/src/jobs/android_test.yml
@@ -48,7 +48,7 @@ parameters:
     description: The version of Node to use. This can be either a major version ("8"), a major and minor ("8.4"), or a fully qualified version ("8.4.1").
     type: string
     default: '10'
-  force_node_version:
+  force_node_version_install:
     description: If you want a specific version of node when running yarn_install.
     type: boolean
     default: false
@@ -59,7 +59,7 @@ steps:
   - setup_macos_executor:
         node_version: <<parameters.node_version>>
   - yarn_install:
-      force_node_version: <<parameters.force_node_version>>
+      force_node_version_install: <<parameters.force_node_version_install>>
   - when:
       condition: <<parameters.on_after_initialize>>
       steps:

--- a/src/jobs/android_test.yml
+++ b/src/jobs/android_test.yml
@@ -40,10 +40,6 @@ parameters:
     enum: ["fatal", "error", "warn", "info", "verbose", "trace"]
     default: warn
   on_after_initialize:
-    description: Set this to true if you want to run a custom shell command right after yarn install. Provide the command in on_after_initialize_command
-    type: boolean
-    default: false
-  on_after_initialize:
     description: A custom command to run right after yarn install.
     type: string
     default: ""
@@ -52,13 +48,18 @@ parameters:
     description: The version of Node to use. This can be either a major version ("8"), a major and minor ("8.4"), or a fully qualified version ("8.4.1").
     type: string
     default: '10'
+  force_node_version:
+    description: If you want a specific version of node when running yarn_install.
+    type: boolean
+    default: false
 
 steps:
   - attach_workspace:
       at: <<parameters.workspace_root>>
   - setup_macos_executor:
         node_version: <<parameters.node_version>>
-  - yarn_install
+  - yarn_install:
+      force_node_version: <<parameters.force_node_version>>
   - when:
       condition: <<parameters.on_after_initialize>>
       steps:

--- a/src/jobs/android_test.yml
+++ b/src/jobs/android_test.yml
@@ -60,6 +60,7 @@ steps:
         node_version: <<parameters.node_version>>
   - yarn_install:
       force_node_version_install: <<parameters.force_node_version_install>>
+      node_version: <<parameters.node_version>>
   - when:
       condition: <<parameters.on_after_initialize>>
       steps:

--- a/src/jobs/ios_build.yml
+++ b/src/jobs/ios_build.yml
@@ -72,6 +72,7 @@ steps:
         node_version: <<parameters.node_version>>
   - yarn_install:
       force_node_version_install: <<parameters.force_node_version_install>>
+      node_version: <<parameters.node_version>>
   - when:
       condition: <<parameters.on_after_initialize>>
       steps:

--- a/src/jobs/ios_build.yml
+++ b/src/jobs/ios_build.yml
@@ -53,6 +53,10 @@ parameters:
     description: The version of Node to use. This can be either a major version ("8"), a major and minor ("8.4"), or a fully qualified version ("8.4.1").
     type: string
     default: '10'
+  force_node_version:
+    description: If you want a specific version of node when running yarn_install.
+    type: boolean
+    default: false
 
 steps:
   - when:
@@ -66,7 +70,8 @@ steps:
             at: <<parameters.workspace_root>>
   - setup_macos_executor:
         node_version: <<parameters.node_version>>
-  - yarn_install
+  - yarn_install:
+      force_node_version: <<parameters.force_node_version>>
   - when:
       condition: <<parameters.on_after_initialize>>
       steps:

--- a/src/jobs/ios_build.yml
+++ b/src/jobs/ios_build.yml
@@ -53,7 +53,7 @@ parameters:
     description: The version of Node to use. This can be either a major version ("8"), a major and minor ("8.4"), or a fully qualified version ("8.4.1").
     type: string
     default: '10'
-  force_node_version:
+  force_node_version_install:
     description: If you want a specific version of node when running yarn_install.
     type: boolean
     default: false
@@ -71,7 +71,7 @@ steps:
   - setup_macos_executor:
         node_version: <<parameters.node_version>>
   - yarn_install:
-      force_node_version: <<parameters.force_node_version>>
+      force_node_version_install: <<parameters.force_node_version_install>>
   - when:
       condition: <<parameters.on_after_initialize>>
       steps:

--- a/src/jobs/ios_build_and_test.yml
+++ b/src/jobs/ios_build_and_test.yml
@@ -88,6 +88,7 @@ steps:
       device: <<parameters.device>>
   - yarn_install:
       force_node_version_install: <<parameters.force_node_version_install>>
+      node_version: <<parameters.node_version>>
   - when:
       condition: <<parameters.on_after_initialize>>
       steps:

--- a/src/jobs/ios_build_and_test.yml
+++ b/src/jobs/ios_build_and_test.yml
@@ -67,6 +67,10 @@ parameters:
     description: The version of Node to use. This can be either a major version ("8"), a major and minor ("8.4"), or a fully qualified version ("8.4.1").
     type: string
     default: "10"
+  force_node_version:
+    description: If you want a specific version of node when running yarn install.
+    type: boolean
+    default: false
 
 steps:
   - when:
@@ -82,7 +86,8 @@ steps:
       node_version: <<parameters.node_version>>
   - ios_simulator_start:
       device: <<parameters.device>>
-  - yarn_install
+  - yarn_install:
+      force_node_version: <<parameters.force_node_version>>
   - when:
       condition: <<parameters.on_after_initialize>>
       steps:

--- a/src/jobs/ios_build_and_test.yml
+++ b/src/jobs/ios_build_and_test.yml
@@ -67,7 +67,7 @@ parameters:
     description: The version of Node to use. This can be either a major version ("8"), a major and minor ("8.4"), or a fully qualified version ("8.4.1").
     type: string
     default: "10"
-  force_node_version:
+  force_node_version_install:
     description: If you want a specific version of node when running yarn install.
     type: boolean
     default: false
@@ -87,7 +87,7 @@ steps:
   - ios_simulator_start:
       device: <<parameters.device>>
   - yarn_install:
-      force_node_version: <<parameters.force_node_version>>
+      force_node_version_install: <<parameters.force_node_version_install>>
   - when:
       condition: <<parameters.on_after_initialize>>
       steps:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
This PRS adds an extra parameter called, that lets you force a specific version of node, when running `yarn install`. I decided to extract this command to a new command called `set_node_version`.

Possible fixes #51 

You can use this passing:

```yml
  - yarn_install:
      force_node_version_install: <<parameters.force_node_version_install>> | true
```

```yml
      - react-native/ios_build_and_test:
          checkout: true
          build_configuration: Release
          detox_configuration: ios.sim.release
          device: iPhone X
          node_version: '10.17'
          project_path: ios/Example.xcworkspace
          force_node_version_install: true
          scheme: Example
```

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan
Run this config, overriding the version passing the specified param overrides the version at `yarn_install`.

Also, I need some helps to understand how can test these changes on the CircleCI. 😅 

### What's required for testing (prerequisites)?
