### PR TITLE
Adding possibility to store Detox artifacts on CircleCI

### DIFF
--- a/src/jobs/android_test.yml
+++ b/src/jobs/android_test.yml
@@ -39,6 +39,10 @@ parameters:
     type: enum
     enum: ["fatal", "error", "warn", "info", "verbose", "trace"]
     default: warn
+  store_artifact_path:
+    description: Stores detox artifacts at CircleCI 
+    type: string
+    default: ""
   on_after_initialize:
     description: Set this to true if you want to run a custom shell command right after yarn install. Provide the command in on_after_initialize_command
     type: boolean
@@ -77,3 +81,8 @@ steps:
   - detox_test:
       configuration: <<parameters.detox_configuration>>
       loglevel: <<parameters.detox_loglevel>>
+  - when:
+      condition: <<parameters.store_artifact_path>>
+      steps:
+        - store_artifacts:
+            path: <<parameters.store_artifact_path>>

--- a/src/jobs/ios_build_and_test.yml
+++ b/src/jobs/ios_build_and_test.yml
@@ -58,6 +58,10 @@ parameters:
     type: enum
     enum: ["fatal", "error", "warn", "info", "verbose", "trace"]
     default: warn
+  store_artifact_path:
+    description: Stores detox artifacts at CircleCI 
+    type: string
+    default: ""
   on_after_initialize:
     description: A custom command to run right after yarn install.
     type: string
@@ -108,3 +112,8 @@ steps:
   - detox_test:
       configuration: <<parameters.detox_configuration>>
       loglevel: <<parameters.detox_loglevel>>
+  - when:
+      condition: <<parameters.store_artifact_path>>
+      steps:
+        - store_artifacts:
+            path: <<parameters.store_artifact_path>>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
This PR implements a param `store_artifact_path` to both `ios_build_test` and `android_test`, that let each job stores the artifacts created with Detox as CircleCI artifacts.

With these changes, I would be able to `zip` the screenshots created by Detox, and then move these files to the CircleCI artifact.

#  Motivation
<!--
Explain the **motivation** for making this change: here are some points to help you:
* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->
Sometimes it's interesting archiving Screenshots, Logs from E2E that can be used as regression tests. This PR let's specify on both jobs for testing an optional path to store these artifacts.



## Test Plan
Just set an `ios_build_test` job following a config similar to this:

```yml
      - react-native/ios_build_and_test:
          checkout: true
          store_artifact_path: /tmp/artifacts/
          node_version: "10.17"
          start_metro: true
          project_type: workspace
          scheme: Example
```
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
Passing these changes to a project, I was able to set dynamically which artifact I would store on CircleCI. 

I used the same command on the CircleCI docs about artifacts:

```shell
            echo "my artifact file" > /tmp/artifact-1;
            mkdir /tmp/artifacts;
            echo "my artifact files in a dir" > /tmp/artifacts/artifact-2;
```

<img width="875" alt="Screen Shot 2020-04-21 at 19 43 30" src="https://user-images.githubusercontent.com/15278828/79921436-91445200-8408-11ea-952a-6c76c45c2927.png">

<img width="1393" alt="Screen Shot 2020-04-21 at 19 42 41" src="https://user-images.githubusercontent.com/15278828/79921451-986b6000-8408-11ea-8671-4e43c40becd3.png">


### What's required for testing (prerequisites)?

