### PR TITLE
fix: fix path to emulator

### DIFF
--- a/src/commands/android_emulator_start.yml
+++ b/src/commands/android_emulator_start.yml
@@ -14,7 +14,7 @@ parameters:
     type: string
     default: "28.0.3"
   logcat_grep:
-    description: ADB logs will be shown in the "Start Android Emulator" commands, but we filter it using grep to avoid noise. You can specify additional strigns to grep for. Make sure you escape special characters.
+    description: ADB logs will be shown in the "Start Android Emulator" commands, but we filter it using grep to avoid noise. You can specify additional strings to grep for. Make sure you escape special characters.
     type: string
     default: "com.reactnativecommunity"
 
@@ -29,7 +29,7 @@ steps:
         yes | sdkmanager "build-tools;<<parameters.build_tools_version>>" >/dev/null
         yes | sdkmanager --licenses >/dev/null
         yes | sdkmanager --list
-  
+
   # to force ssh key generation for emulators
   - run:
       name: ADB Start Stop
@@ -46,8 +46,8 @@ steps:
   - run:
       name: Start Android Emulator (background)
       command: |
-        /usr/local/share/android-sdk/emulator/emulator @<<parameters.device_name>> -version
-        /usr/local/share/android-sdk/emulator/emulator @<<parameters.device_name>> -skin 470x860 -cores 1 -gpu auto -accel on -memory 1024 -no-audio -no-snapshot -no-boot-anim -no-window -logcat *:W | grep -i 'ReactNative\|<<parameters.logcat_grep>>'
+        $ANDROID_HOME/emulator/emulator @<<parameters.device_name>> -version
+        $ANDROID_HOME/emulator/emulator @<<parameters.device_name>> -skin 470x860 -cores 1 -gpu auto -accel on -memory 1024 -no-audio -no-snapshot -no-boot-anim -no-window -logcat *:W | grep -i 'ReactNative\|<<parameters.logcat_grep>>'
       background: true
 
   - run:

--- a/src/jobs/android_test.yml
+++ b/src/jobs/android_test.yml
@@ -26,7 +26,7 @@ parameters:
     type: string
     default: "28.0.3"
   logcat_grep:
-    description: ADB logs will be shown in the "Start Android Emulator" commands, but we filter it using grep to avoid noise. You can specify additional strigns to grep for. Make sure you escape special characters. Defaults to 'com.reactnativecommunity'.
+    description: ADB logs will be shown in the "Start Android Emulator" commands, but we filter it using grep to avoid noise. You can specify additional strings to grep for. Make sure you escape special characters. Defaults to 'com.reactnativecommunity'.
     type: string
     default: "com.reactnativecommunity"
   # For the detox command


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

motivation: the path to emulator used in the orb is not always the right one, this should fix it

## Test Plan

this change is used in https://github.com/react-native-community/datetimepicker/pull/155

after some fighting, you see tests are passing

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
