### PR TITLE
feat: follow emulator best practices

### DIFF
--- a/src/commands/android_emulator_start.yml
+++ b/src/commands/android_emulator_start.yml
@@ -29,7 +29,7 @@ steps:
         yes | sdkmanager "build-tools;<<parameters.build_tools_version>>" >/dev/null
         yes | sdkmanager --licenses >/dev/null
         yes | sdkmanager --list
-  
+
   # to force ssh key generation for emulators
   - run:
       name: ADB Start Stop
@@ -41,7 +41,10 @@ steps:
 
   - run:
       name: Create Android Emulator
-      command: avdmanager create avd --force -n <<parameters.device_name>> -k "system-images;<<parameters.platform_version>>;google_apis;x86" -g google_apis -d "Nexus 4"
+      command:
+        avdmanager create avd --force --name <<parameters.device_name>> --package
+        "system-images;<<parameters.platform_version>>;default;x86_64" --tag
+        default --device pixel
 
   - run:
       name: Start Android Emulator (background)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

this is potentially breaking because it removes google-services from the emulator - but I don't imagine people use those much (also considering that starting the emulator has been broken). This makes the command to follow emulator best practices collected by wix: https://github.com/wix/Detox/blob/master/docs/Introduction.AndroidEmulatorsBestPractices.md

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

used in https://github.com/react-native-community/datetimepicker/pull/155

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
