### PR TITLE
Fix orb pack command

### DIFF
--- a/src/jobs/android_test.yml
+++ b/src/jobs/android_test.yml
@@ -43,7 +43,7 @@ parameters:
     description: Stores detox artifacts at CircleCI 
     type: string
     default: ""
-  on_after_initialize:
+  should_on_after_initialize:
     description: Set this to true if you want to run a custom shell command right after yarn install. Provide the command in on_after_initialize_command
     type: boolean
     default: false
@@ -64,7 +64,7 @@ steps:
         node_version: <<parameters.node_version>>
   - yarn_install
   - when:
-      condition: <<parameters.on_after_initialize>>
+      condition: <<parameters.should_on_after_initialize>>
       steps:
         - run:
             name: "on_after_initialize"


### PR DESCRIPTION
```bash
#!/bin/bash -eo pipefail
circleci config pack src/ > packed-orb.yml
Error: Failed trying to marshal the tree to YAML : yaml: unmarshal errors:
  line 50: mapping key "on_after_initialize" already defined at line 46
Exited with code exit status 255
```

`circleci config pack` was failing due to a duplicated parameter