### PR TITLE
Remove deprecated CircleCI spec repo cache for pod install step

### DIFF
--- a/src/commands/pod_install.yml
+++ b/src/commands/pod_install.yml
@@ -1,4 +1,4 @@
-description: install pods, use CircleCI cache to fetch CocoaPods specs
+description: install pods
 
 # note: do not use the --project-directory pod param because many example
 # projects in the rn community repos rely on pod install to be run from ios directory
@@ -17,7 +17,6 @@ steps:
   - run:
       name: Install CocoaPods
       command: |
-        curl https://cocoapods-specs.circleci.com/fetch-cocoapods-repo-from-s3.sh | bash -s cf
         cd <<parameters.pod_install_directory>> && pod install && cd -
   - save_cache:
       paths:


### PR DESCRIPTION
The CircleCI spec repo cache was deprecated some time ago and whilst it is still up, has not been updated for a long time now. Eventually this will lead to failed pod installs where newer packages cannot be found in the repo.

Moving forward, we recommend the use of the Cocoapods CDN as it is significantly faster and more reliable than using the specs repo. The choice of using this will be down to the user to define in their Podfile.

References: 

https://circleci.com/docs/2.0/testing-ios/#optimizing-cocoapods
https://support.circleci.com/hc/en-us/articles/360045898974-Cocoapods-Spec-Repo-is-Outdated