### PR TITLE
Remove deprecated cask usage from brew install

### DIFF
--- a/src/commands/setup_macos_executor.yml
+++ b/src/commands/setup_macos_executor.yml
@@ -44,7 +44,7 @@ steps:
         HOMEBREW_NO_AUTO_UPDATE=1 brew tap wix/brew >/dev/null
         HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/cask >/dev/null
         HOMEBREW_NO_AUTO_UPDATE=1 brew install applesimutils >/dev/null
-        HOMEBREW_NO_AUTO_UPDATE=1 brew cask install android-sdk >/dev/null
+        HOMEBREW_NO_AUTO_UPDATE=1 brew install --cask android-sdk >/dev/null
         touch .watchmanconfig
         node -v
 


### PR DESCRIPTION
I get this error in ci 
```
#!/bin/bash --login -eo pipefail
HOMEBREW_NO_AUTO_UPDATE=1 brew tap wix/brew >/dev/null
HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/cask >/dev/null
HOMEBREW_NO_AUTO_UPDATE=1 brew install applesimutils >/dev/null
HOMEBREW_NO_AUTO_UPDATE=1 brew cask install android-sdk >/dev/null
touch .watchmanconfig
node -v

v10.24.0 is already installed.
Now using node v10.24.0 (npm v6.14.11)
default -> 10 (-> v10.24.0 *)
v10.24.0 is already installed.
==> Tapping wix/brew
Cloning into '/usr/local/Homebrew/Library/Taps/wix/homebrew-brew'...
remote: Enumerating objects: 78, done.        
remote: Counting objects: 100% (78/78), done.        
remote: Compressing objects: 100% (44/44), done.        
remote: Total 622 (delta 41), reused 58 (delta 22), pack-reused 544        
Receiving objects: 100% (622/622), 1.58 MiB | 9.08 MiB/s, done.
Resolving deltas: 100% (328/328), done.
Tapped 1 cask and 1 formula (31 files, 1.6MB).
v10.24.0 is already installed.
==> Tapping homebrew/cask
Cloning into '/usr/local/Homebrew/Library/Taps/homebrew/homebrew-cask'...
remote: Enumerating objects: 24, done.        
remote: Counting objects: 100% (24/24), done.        
remote: Compressing objects: 100% (20/20), done.        
remote: Total 554059 (delta 10), reused 7 (delta 4), pack-reused 554035        
Receiving objects: 100% (554059/554059), 245.03 MiB | 38.90 MiB/s, done.
Resolving deltas: 100% (391204/391204), done.
Tapped 3855 casks (3,972 files, 262.8MB).
v10.24.0 is already installed.
v10.24.0 is already installed.
Error: Calling `brew cask install` is disabled! Use brew install [--cask] instead.

Exited with code exit status 1
```