### PR TITLE
Replace cache version with branch in yarn_install command

### DIFF
--- a/src/commands/yarn_install.yml
+++ b/src/commands/yarn_install.yml
@@ -9,7 +9,7 @@ steps:
         find . -type f -name 'yarn.lock' -not -path "*node_modules*" -exec cat {} + >> ~/.tmp/checksumfiles/yarn.lock
   - restore_cache:
       keys:
-        - yarn-cache-{{ arch }}-{{ checksum "~/.tmp/checksumfiles/package.json" }}-{{ checksum "~/.tmp/checksumfiles/yarn.lock" }}-{{ .Environment.CACHE_VERSION }}
+        - yarn-cache-{{ arch }}-{{ .Branch }}-{{ checksum "~/.tmp/checksumfiles/package.json" }}-{{ checksum "~/.tmp/checksumfiles/yarn.lock" }}
   - run:
       name: Yarn Install
       command: yarn install --frozen-lockfile --non-interactive --cache-folder /tmp/yarn
@@ -17,4 +17,4 @@ steps:
       paths:
         - /tmp/yarn
       key: |
-        yarn-cache-{{ arch }}-{{ checksum "~/.tmp/checksumfiles/package.json" }}-{{ checksum "~/.tmp/checksumfiles/yarn.lock" }}-{{ .Environment.CACHE_VERSION }}
+        yarn-cache-{{ arch }}-{{ .Branch }}-{{ checksum "~/.tmp/checksumfiles/package.json" }}-{{ checksum "~/.tmp/checksumfiles/yarn.lock" }}


### PR DESCRIPTION
Fixes #66 by replacing `.Environment.CACHE_VERSION` with `.Branch`. [Reference](https://support.circleci.com/hc/en-us/articles/360056920051--Error-untarring-cache-when-running-a-macOS-job). 

The `CACHE_VERSION` was failing in the `ios_build` job, and seemingly it needed to have the cache version updated manually in environment secrets on each run.

