### PR TITLE
feat: add parameter to allow configuring the android tests on build

### DIFF
--- a/src/commands/android_build.yml
+++ b/src/commands/android_build.yml
@@ -13,6 +13,11 @@ parameters:
     description: Save and restore the caches? Defaults to true
     type: boolean
     default: true
+  assemble_android_test:
+    description: Configure the android tests to run. Defaults to assembleAndroidTest
+    type: enum
+    enum: ["", "assembleAndroidTest", "app:assembleAndroidTest"]
+    default: assembleAndroidTest
 
 steps:
   - when:
@@ -69,7 +74,7 @@ steps:
 
   - run:
       name: Build Android APK
-      command: "cd <<parameters.project_path>> && chmod +x gradlew && ./gradlew --build-cache --max-workers 2 --continue assemble<<parameters.build_type>> assembleAndroidTest -DtestBuildType=<<parameters.build_type>> --stacktrace"
+      command: "cd <<parameters.project_path>> && chmod +x gradlew && ./gradlew --build-cache --max-workers 2 --continue assemble<<parameters.build_type>> <<parameters.assemble_android_test>> -DtestBuildType=<<parameters.build_type>> --stacktrace"
 
   - when:
       condition: <<parameters.cache>>


### PR DESCRIPTION
Adds a parameter to #100 where android builds will fail at the assembleAndroidTest portion due to minSdkVersion in react-native 0.64 increasing from 16 to 21, meaning that dependencies such as `react-native-splash-screen` error