### PR TITLE
Make yarn cache folder configurable

### DIFF
--- a/src/commands/yarn_install.yml
+++ b/src/commands/yarn_install.yml
@@ -5,6 +5,10 @@ parameters:
     description: Save and restore the build cache? Defaults to true
     type: boolean
     default: true
+  cache_folder:
+    description: The path to the yarn cache folder.  Defaults to /tmp/yarn
+    type: string
+    default: "/tmp/yarn"
 
 steps:
   - when:
@@ -21,12 +25,12 @@ steps:
               - yarn-cache-{{ arch }}-{{ checksum "~/.tmp/checksumfiles/package.json" }}-{{ checksum "~/.tmp/checksumfiles/yarn.lock" }}-{{ .Environment.CACHE_VERSION }}
   - run:
       name: Yarn Install
-      command: yarn install --frozen-lockfile --non-interactive --cache-folder /tmp/yarn
+      command: "yarn install --frozen-lockfile --non-interactive --cache-folder <<parameters.cache_folder>>"
   - when:
       condition: <<parameters.cache>>
       steps:
         - save_cache:
             paths:
-              - /tmp/yarn
+              - <<parameters.cache_folder>>
             key: |
               yarn-cache-{{ arch }}-{{ checksum "~/.tmp/checksumfiles/package.json" }}-{{ checksum "~/.tmp/checksumfiles/yarn.lock" }}-{{ .Environment.CACHE_VERSION }}

--- a/src/jobs/ios_build.yml
+++ b/src/jobs/ios_build.yml
@@ -24,6 +24,10 @@ parameters:
     description: Should we cache after yarn install? Defaults to true
     type: boolean
     default: true
+  yarn_cache_folder:
+    description: The path to the yarn cache folder
+    type: string
+    default: "/tmp/yarn"
   # For the iOS build command
   project_type:
     description: If the iOS app is built using a project file (*.xcodeproj) or a workspace.
@@ -81,6 +85,7 @@ steps:
       homebrew_cache: <<parameters.homebrew_cache>>
   - yarn_install:
       cache: <<parameters.yarn_cache>>
+      cache_folder: <<parameters.yarn_cache_folder>>
   - when:
       condition: <<parameters.on_after_initialize>>
       steps:

--- a/src/jobs/ios_build_and_test.yml
+++ b/src/jobs/ios_build_and_test.yml
@@ -28,6 +28,10 @@ parameters:
     description: Should we cache after yarn install? Defaults to true
     type: boolean
     default: true
+  yarn_cache_folder:
+    description: The path to the yarn cache folder
+    type: string
+    default: "/tmp/yarn"
   # For the iOS build command
   project_type:
     description: If the iOS app is built using a project file (*.xcodeproj) or a workspace.
@@ -101,6 +105,7 @@ steps:
       device: <<parameters.device>>
   - yarn_install:
       cache: <<parameters.yarn_cache>>
+      cache_folder: <<parameters.yarn_cache_folder>>
   - when:
       condition: <<parameters.on_after_initialize>>
       steps:


### PR DESCRIPTION
Allow users to choose their own yarn caching folder, and let people try various strategies to resolve an open unarchiving issue https://github.com/react-native-community/react-native-circleci-orb/issues/66 (seemingly caused by changing this hard-coded path from one location to another [here](https://github.com/react-native-community/react-native-circleci-orb/pull/59)).

Defaults to the current path in `master` so this is a non-breaking change.