### PR TITLE
Cache node_modules when yarn cache is enabled

### DIFF
--- a/src/commands/yarn_install.yml
+++ b/src/commands/yarn_install.yml
@@ -32,5 +32,6 @@ steps:
         - save_cache:
             paths:
               - <<parameters.cache_folder>>
+              - node_modules
             key: |
               yarn-cache-{{ arch }}-{{ checksum "~/.tmp/checksumfiles/package.json" }}-{{ checksum "~/.tmp/checksumfiles/yarn.lock" }}-{{ .Environment.CACHE_VERSION }}


### PR DESCRIPTION
Caching node_modules seems to be saving 1.5-2 minutes per build time.