### PR TITLE
Add optional command-running step after the emulator starts

### DIFF
--- a/src/jobs/android_test.yml
+++ b/src/jobs/android_test.yml
@@ -48,11 +48,19 @@ parameters:
     type: string
     default: ""
   should_on_after_initialize:
-    description: Set this to true if you want to run a custom shell command right after yarn install. Provide the command in on_after_initialize_command
+    description: Set this to true if you want to run a custom shell command right after yarn install. Provide the command in on_after_initialize command.
     type: boolean
     default: false
   on_after_initialize:
     description: A custom command to run right after yarn install.
+    type: string
+    default: ""
+  should_on_after_emulator_start:
+    description: Set this to true if you want to run a custom shell command right after the android emulator starts. Provide the command in on_after_emulator_start command.
+    type: boolean
+    default: false
+  on_after_emulator_start:
+    description: A custom command to run right after the android emulator starts.
     type: string
     default: ""
   # For macos executor
@@ -88,6 +96,12 @@ steps:
       platform_version: <<parameters.platform_version>>
       build_tools_version: <<parameters.build_tools_version>>
       logcat_grep: <<parameters.logcat_grep>>
+  - when:
+      condition: <<parameters.should_on_after_emulator_start>>
+      steps:
+        - run:
+            name: "on_after_emulator_start"
+            command: <<parameters.on_after_emulator_start>>
   - detox_test:
       configuration: <<parameters.detox_configuration>>
       loglevel: <<parameters.detox_loglevel>>


### PR DESCRIPTION
Add the ability to run commands after the emulator starts but before the detox tests run.

This will enable people to run common commands needed for UI automation, ex: https://testyour.app/blog/emulator