### PR TITLE
Added new Android Command Line Tools for MacOS 12+ and Java 9, 10, 11

### DIFF
--- a/src/commands/setup_macos_executor.yml
+++ b/src/commands/setup_macos_executor.yml
@@ -48,6 +48,7 @@ steps:
   - run:
       name: Configure Detox Environment
       command: |
+        brew update >/dev/null
         HOMEBREW_NO_AUTO_UPDATE=1 brew tap wix/brew >/dev/null
         HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/cask >/dev/null
         HOMEBREW_NO_AUTO_UPDATE=1 brew install applesimutils >/dev/null


### PR DESCRIPTION
This PR upgrades the orb to use the latest version of the Android Command Line tools (https://formulae.brew.sh/cask/android-commandlinetools) and allow Android emulator to be started successfully on executor macos/xcode 12.0 and +. Running the `android_emulator_start` command with macos/xcode set as 12.0 or greater will result in the following issue: 

```
Exception in thread "main" java.lang.NoClassDefFoundError: javax/xml/bind/annotation/XmlSchema
	at com.android.repository.api.SchemaModule$SchemaModuleVersion.<init>(SchemaModule.java:156)
	at com.android.repository.api.SchemaModule.<init>(SchemaModule.java:75)
	at com.android.sdklib.repository.AndroidSdkHandler.<clinit>(AndroidSdkHandler.java:81)
	at com.android.sdklib.tool.sdkmanager.SdkManagerCli.main(SdkManagerCli.java:73)
	at com.android.sdklib.tool.sdkmanager.SdkManagerCli.main(SdkManagerCli.java:48)
Caused by: java.lang.ClassNotFoundException: javax.xml.bind.annotation.XmlSchema
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	... 5 more
```

This is because the `android-sdk` (deprecated) requires Java 8 while the Java version which comes with specifying xCode 12 or greater is Java 11+. To fix this we must start using the new Android command line tools provided via the brew package `android-commandlinetools`.

Closes #89

Note: After these changes we were able to run the `react-native/android_emulator_start` command successfully with macos/xcode as '12.4.0'.