### PR TITLE
fix: do not cache /usr/local/Homebrew

### DIFF
--- a/src/commands/setup_macos_executor.yml
+++ b/src/commands/setup_macos_executor.yml
@@ -61,7 +61,6 @@ steps:
       steps:
         - save_cache:
             paths:
-              - /usr/local/Homebrew
               - ~/Library/Caches/Homebrew
             key: |
               brew-cache-{{ arch }}-{{ .Environment.CACHE_VERSION }}


### PR DESCRIPTION
closes #117 

I have been hitting the same error in RN date time picker

I'm not entirely sure why that folder should or should not be cached but I'm led to believe it should not be cached because

(1) it causes an error 😄  and not caching it makes CI pass
(2) it is not empty from the start, so untarring the archive attempts to overwrite something that existed before so I guess it could lead to inconsistencies or bugs like #117 

the `~/Library/Caches/Homebrew` folder is empty upon start so caching that one seems to make sense
