### PR TITLE
fix(android): pin docker image to 4.2 for JDK8

### DIFF
--- a/src/executors/linux_android.yml
+++ b/src/executors/linux_android.yml
@@ -12,7 +12,7 @@ parameters:
     type: string
     default: medium
 docker:
-  - image: reactnativecommunity/react-native-android
+  - image: reactnativecommunity/react-native-android:4.2
 resource_class: <<parameters.resource_class>>
 environment:
   - _JAVA_OPTIONS: <<parameters.java_options>>


### PR DESCRIPTION
This is needed so that the JDK options work, see:
https://discuss.circleci.com/t/unrecognized-vm-option-usecgroupmemorylimitforheap/37088
Related #120

This should be released as the final release in the current semver minor range I think, as suggested by @cortinico here
https://github.com/react-native-community/react-native-circleci-orb/issues/120#issuecomment-970220152