### PR TITLE
fix(android)!: use JDK11 compatible JVM options

### DIFF
--- a/src/executors/linux_android.yml
+++ b/src/executors/linux_android.yml
@@ -2,7 +2,7 @@ parameters:
   java_options:
     description: Java command options. Note that setting this will override the default options so you might need to supply those as well.
     type: string
-    default: '-Xmx1024m -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap'
+    default: '-Xmx1024m -XX:+UnlockExperimentalVMOptions -XX:+UseContainerSupport'
   gradle_options:
     description: Gradle command options. Note that setting this will override the default options so you might need to supply those as well.
     type: string


### PR DESCRIPTION
See JDK8-->JDK11 migration notes here:
https://discuss.circleci.com/t/android-convenience-image-moving-to-java-v11-on-august-17th/36601/4
Related #120

BREAKING CHANGE: this orb is now officially using JDK11