### PR TITLE
fix(android): move docker android pin to JDK11 version

### DIFF
--- a/src/executors/linux_android.yml
+++ b/src/executors/linux_android.yml
@@ -12,7 +12,7 @@ parameters:
     type: string
     default: medium
 docker:
-  - image: reactnativecommunity/react-native-android:4.2
+  - image: reactnativecommunity/react-native-android:5.1
 resource_class: <<parameters.resource_class>>
 environment:
   - _JAVA_OPTIONS: <<parameters.java_options>>


### PR DESCRIPTION
The JVM options were coordinated with JDK8 + v4.x docker version pin earlier,
the JVM options were moved to JDK11 in #122 but the pin wasn't moved
They should be in sync with this