### PR TITLE
yarn_install - add optional yarn_install_directory parameter

### DIFF
--- a/src/commands/yarn_install.yml
+++ b/src/commands/yarn_install.yml
@@ -10,7 +10,7 @@ parameters:
     type: string
     default: "/tmp/yarn"
   yarn_install_directory:
-    description: The working directory to run install at. Defaults to current directory
+    description: The working directory to run install at. Defaults to yarn's current working directory
     type: string
     default: ""
 
@@ -27,9 +27,20 @@ steps:
         - restore_cache:
             keys:
               - yarn-cache-{{ arch }}-{{ checksum "~/.tmp/checksumfiles/package.json" }}-{{ checksum "~/.tmp/checksumfiles/yarn.lock" }}-{{ .Environment.CACHE_VERSION }}
-  - run:
-      name: Yarn Install
-      command: "yarn --cwd <<parameters.yarn_install_directory>> install --frozen-lockfile --non-interactive --cache-folder <<parameters.cache_folder>>"
+  - when:
+      condition:
+        equal: ["", <<parameters.yarn_install_directory>>]
+      steps:
+        - run:
+            name: Yarn Install
+            command: "yarn install --frozen-lockfile --non-interactive --cache-folder <<parameters.cache_folder>>"
+  - unless:
+      condition:
+        equal: ["", <<parameters.yarn_install_directory>>]
+      steps:
+        - run:
+            name: Yarn Install (<<parameters.yarn_install_directory>>)
+            command: "yarn --cwd <<parameters.yarn_install_directory>> install --frozen-lockfile --non-interactive --cache-folder <<parameters.cache_folder>>"
   - when:
       condition: <<parameters.cache>>
       steps:

--- a/src/commands/yarn_install.yml
+++ b/src/commands/yarn_install.yml
@@ -10,8 +10,9 @@ parameters:
     type: string
     default: "/tmp/yarn"
   yarn_install_directory:
-    description: The working directory to run install at. Defaults to currenct directory
+    description: The working directory to run install at. Defaults to current directory
     type: string
+    default: ""
 
 steps:
   - when:

--- a/src/commands/yarn_install.yml
+++ b/src/commands/yarn_install.yml
@@ -9,6 +9,9 @@ parameters:
     description: The path to the yarn cache folder.  Defaults to /tmp/yarn
     type: string
     default: "/tmp/yarn"
+  yarn_install_directory:
+    description: The working directory to run install at. Defaults to currenct directory
+    type: string
 
 steps:
   - when:
@@ -25,7 +28,7 @@ steps:
               - yarn-cache-{{ arch }}-{{ checksum "~/.tmp/checksumfiles/package.json" }}-{{ checksum "~/.tmp/checksumfiles/yarn.lock" }}-{{ .Environment.CACHE_VERSION }}
   - run:
       name: Yarn Install
-      command: "yarn install --frozen-lockfile --non-interactive --cache-folder <<parameters.cache_folder>>"
+      command: "yarn --cwd <<parameters.yarn_install_directory>> install --frozen-lockfile --non-interactive --cache-folder <<parameters.cache_folder>>"
   - when:
       condition: <<parameters.cache>>
       steps:


### PR DESCRIPTION
## Motivation
Similar to `pod_install`'s `pod_install_directory` parameter, this adds a `yarn_install_directory` to `yarn_install`

## Description
Sometimes the `package.json` file isn't in the current/root directory so this option allows for project configurations where the `package.json` file is somewhere else

- Defaults to an empty string which will run as previously did `yarn install`
- Runs `yarn --cwd <<yarn_install_directory>>` if any non-empty string value is used

### Example
```yaml
- yarn_install:
    yarn_install_directory: examples/oneOfMyExampleApps
    cache_folder: ~/.cache/yarn
```