### PR TITLE
Document that an empty `pod_install_directory` will skip `pod install`

### DIFF
--- a/src/jobs/ios_build_and_test.yml
+++ b/src/jobs/ios_build_and_test.yml
@@ -23,7 +23,7 @@ parameters:
   pod_install_directory:
     type: string
     default: ""
-    description: The location of the "ios" directory for `pod install`
+    description: The location of the "ios" directory for `pod install`. Will skip `pod install` if missing.
   yarn_cache:
     description: Should we cache after yarn install? Defaults to true
     type: boolean


### PR DESCRIPTION
I was surprised that `pod install` wasn't happening. I expected it to default the directory to `ios`, since that's the most common arrangement. It makes sense to me to only `pod install` if `pod_install_directory` is set, but I had to look at the implementation to confirm that that's what it was doing. So this should make it clearer for the next person.