### PR TITLE
Added background parameter to ios_simulator_start.yml

### DIFF
--- a/src/commands/ios_simulator_start.yml
+++ b/src/commands/ios_simulator_start.yml
@@ -5,9 +5,13 @@ parameters:
     description: The type of device you want to start.
     type: string
     default: "iPhone X"
+  background:
+    default: true
+    description: Should ios simulator boot in background?
+    type: boolean
 
 steps:
   - run:
       name: Start iOS simulator (background)
-      background: true
+      background: <<parameters.background>>
       command: xcrun simctl boot "<<parameters.device>>" || true


### PR DESCRIPTION
### Why?

This is useful if you need to wait for the command to finish and simulator to boot before proceeding. Say for example you were running `xcrun simctl addmedia booted` without specifying `background: false` you would run into `No devices are booted` issue.