### PR TITLE
fix(ios): update default ios device to iPhone 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ workflows:
       - rn/ios_build:
           name: build_ios_release
           project_path: ios/Example.xcodeproj
-          device: "iPhone X"
+          device: "iPhone 11"
           build_configuration: Release
           scheme: Example
           requires:
@@ -130,7 +130,7 @@ workflows:
       # Build and test the iOS app in release mode
       - rn/ios_build_and_test:
           project_path: "ios/Example.xcodeproj"
-          device: "iPhone X"
+          device: "iPhone 11"
           build_configuration: "Release"
           scheme: "Example"
           detox_configuration: "ios.sim.release"

--- a/src/commands/ios_build.yml
+++ b/src/commands/ios_build.yml
@@ -20,7 +20,7 @@ parameters:
   device:
     description: The type of device you want to build for.
     type: string
-    default: "iPhone X"
+    default: "iPhone 11"
   scheme:
     description: The scheme to use.
     type: string

--- a/src/commands/ios_simulator_start.yml
+++ b/src/commands/ios_simulator_start.yml
@@ -4,7 +4,7 @@ parameters:
   device:
     description: The type of device you want to start.
     type: string
-    default: "iPhone X"
+    default: "iPhone 11"
   background:
     default: true
     description: Should ios simulator boot in background?

--- a/src/examples/full.yml
+++ b/src/examples/full.yml
@@ -91,7 +91,7 @@ usage:
             name: build_ios_release
             node_version: '12'
             project_path: ios/Example.xcodeproj
-            device: "iPhone X"
+            device: "iPhone 11"
             build_configuration: Release
             scheme: Example
             requires:
@@ -101,7 +101,7 @@ usage:
         - rn/ios_build_and_test:
             node_version: '12'
             project_path: "ios/Example.xcodeproj"
-            device: "iPhone X"
+            device: "iPhone 11"
             build_configuration: "Release"
             scheme: "Example"
             detox_configuration: "ios.sim.release"

--- a/src/examples/ios.yml
+++ b/src/examples/ios.yml
@@ -62,7 +62,7 @@ usage:
         - rn/ios_build:
             name: build_ios_release
             project_path: ios/Example.xcodeproj
-            device: "iPhone X"
+            device: "iPhone 11"
             build_configuration: Release
             scheme: Example
             requires:
@@ -71,7 +71,7 @@ usage:
         # Build and test the iOS app in release mode
         - rn/ios_build_and_test:
             project_path: "ios/Example.xcodeproj"
-            device: "iPhone X"
+            device: "iPhone 11"
             build_configuration: "Release"
             scheme: "Example"
             detox_configuration: "ios.sim.release"

--- a/src/jobs/ios_build.yml
+++ b/src/jobs/ios_build.yml
@@ -48,7 +48,7 @@ parameters:
   device:
     description: The type of device you want to build for.
     type: string
-    default: "iPhone X"
+    default: "iPhone 11"
   scheme:
     description: The scheme to use.
     type: string

--- a/src/jobs/ios_build_and_test.yml
+++ b/src/jobs/ios_build_and_test.yml
@@ -52,7 +52,7 @@ parameters:
   device:
     description: The type of device you want to build for.
     type: string
-    default: "iPhone X"
+    default: "iPhone 11"
   scheme:
     description: The scheme to use.
     type: string


### PR DESCRIPTION
Xcode 13 by default no longer includes support for iPhone X out of the box. This PR replaces the default iOS device to iPhone 11.