### PR TITLE
fix(android): fix gradle build cache key

### DIFF
--- a/src/commands/android_build.yml
+++ b/src/commands/android_build.yml
@@ -92,5 +92,5 @@ steps:
             name: Saving Gradle Build caches
             paths:
               - ~/gradle-build-caches
-            key: gradle-debug-build-cache-{{ .Revision }}
+            key: gradle-build-cache-{{ .Revision }}
             when: always


### PR DESCRIPTION
## Description

Fixes the `gradle` build cache key using for saving. It should [match the key used during restore](https://github.com/react-native-community/react-native-circleci-orb/blob/v6.2.1/src/commands/android_build.yml#L40-L43), otherwise there will never be a cache hit.

<img width="1305" alt="gradle-cache-key" src="https://user-images.githubusercontent.com/11336/151455158-709875a8-04ef-4455-94f4-ebf30728956c.png">

If the `build_type` needs to be taken into consideration, I can update the PR to:

```diff
diff --git a/src/commands/android_build.yml b/src/commands/android_build.yml
index 68bd274..befedfb 100644
--- a/src/commands/android_build.yml
+++ b/src/commands/android_build.yml
@@ -40,7 +40,7 @@ steps:
         - restore_cache:
             name: Restoring Gradle Build caches
             keys:
-              - gradle-build-cache-{{ .Revision }}
+              - gradle-<<parameters.build_type>>-build-cache-{{ .Revision }}

   - run:
       name: Dispersing Gradle Build caches for restoring
@@ -92,5 +92,5 @@ steps:
             name: Saving Gradle Build caches
             paths:
               - ~/gradle-build-caches
-            key: gradle-debug-build-cache-{{ .Revision }}
+            key: gradle-<<parameters.build_type>>-build-cache-{{ .Revision }}
             when: always
```