### PR TITLE
Add homebrew_update parameter to toggle brew update

### DIFF
--- a/src/commands/setup_macos_executor.yml
+++ b/src/commands/setup_macos_executor.yml
@@ -9,6 +9,10 @@ parameters:
     description: Should we cache after brew install? Defaults to true
     type: boolean
     default: true
+  homebrew_update:
+    description: Should we run brew update? Defaults to true
+    type: boolean
+    default: true
 
 steps:
   - run:
@@ -45,9 +49,12 @@ steps:
       name: Verify node version
       command: node --version
 
-  - run:
-      name: Update brew
-      command: brew update >/dev/null
+  - when:
+      condition: <<parameters.homebrew_update>>
+      steps:
+        - run:
+            name: Update brew
+            command: brew update >/dev/null
 
   - run:
       name: Configure Detox Environment

--- a/src/commands/setup_macos_executor.yml
+++ b/src/commands/setup_macos_executor.yml
@@ -46,9 +46,12 @@ steps:
       command: node --version
 
   - run:
+      name: Update brew
+      command: brew update >/dev/null
+
+  - run:
       name: Configure Detox Environment
       command: |
-        brew update >/dev/null
         HOMEBREW_NO_AUTO_UPDATE=1 brew tap wix/brew >/dev/null
         HOMEBREW_NO_AUTO_UPDATE=1 brew tap homebrew/cask >/dev/null
         HOMEBREW_NO_AUTO_UPDATE=1 brew install applesimutils >/dev/null

--- a/src/jobs/android_test.yml
+++ b/src/jobs/android_test.yml
@@ -72,6 +72,10 @@ parameters:
     description: Should we cache after brew install? Defaults to true
     type: boolean
     default: true
+  homebrew_update:
+    description: Should we run brew update? Defaults to true
+    type: boolean
+    default: true
 
 steps:
   - attach_workspace:
@@ -79,6 +83,7 @@ steps:
   - setup_macos_executor:
       node_version: <<parameters.node_version>>
       homebrew_cache: <<parameters.homebrew_cache>>
+      homebrew_update: <<parameters.homebrew_update>>
   - yarn_install:
       cache: <<parameters.yarn_cache>>
   - when:

--- a/src/jobs/ios_build.yml
+++ b/src/jobs/ios_build.yml
@@ -69,6 +69,10 @@ parameters:
     description: Should we cache after brew install? Defaults to true
     type: boolean
     default: true
+  homebrew_update:
+    description: Should we run brew update? Defaults to true
+    type: boolean
+    default: true
 
 steps:
   - when:
@@ -83,6 +87,7 @@ steps:
   - setup_macos_executor:
       node_version: <<parameters.node_version>>
       homebrew_cache: <<parameters.homebrew_cache>>
+      homebrew_update: <<parameters.homebrew_update>>
   - yarn_install:
       cache: <<parameters.yarn_cache>>
       cache_folder: <<parameters.yarn_cache_folder>>

--- a/src/jobs/ios_build_and_test.yml
+++ b/src/jobs/ios_build_and_test.yml
@@ -87,6 +87,10 @@ parameters:
     description: Should we cache after brew install? Defaults to true
     type: boolean
     default: true
+  homebrew_update:
+    description: Should we run brew update? Defaults to true
+    type: boolean
+    default: true
 
 steps:
   - when:
@@ -101,6 +105,7 @@ steps:
   - setup_macos_executor:
       node_version: <<parameters.node_version>>
       homebrew_cache: <<parameters.homebrew_cache>>
+      homebrew_update: <<parameters.homebrew_update>>
   - ios_simulator_start:
       device: <<parameters.device>>
   - yarn_install:


### PR DESCRIPTION
## Description

Currently setting up the `Detox Environment` takes over 7 mins:

<img width="1312" alt="brew_update" src="https://user-images.githubusercontent.com/11336/151618999-7c6d9e7f-b201-4ebf-8845-af8a72ca9e9f.png">

The vast majority of the time is spent in `brew update`. With the introduction of `brew update` in #114 there is time penalty in every run. Unfortunately [CircleCI doesn't intent to update](https://ideas.circleci.com/images/p/run-brew-update-regularly-on-macos-images) the host machine regularly, which could alleviate the situation.

This PR is adding the ability to toggle `brew update`. The default remains to run `brew update` to avoid breaking changes.