### PR TITLE
Move the orb link to source_url

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,4 +1,7 @@
 version: 2.1
+
 description: |
-  Orb for building and testing React Native projects. View
-  this orb's source: https://github.com/react-native-community/react-native-circleci-orb
+  Orb for building and testing React Native projects.
+
+display:
+  source_url: "https://github.com/react-native-community/react-native-circleci-orb"


### PR DESCRIPTION
## Description

Current the source code URL is part of the description and [not clickable](https://circleci.com/developer/orbs/orb/react-native-community/react-native?version=6.2.2):

<img width="664" alt="source-url" src="https://user-images.githubusercontent.com/11336/151706074-8a6784b7-78b6-4ae2-95bd-d80edac6541b.png">

With this PR the URL is gonna become more visible and clickable, akin to [`circleci/android`](https://circleci.com/developer/orbs/orb/circleci/android):

<img width="668" alt="circleci-orb-android" src="https://user-images.githubusercontent.com/11336/151706125-ddc4ab5b-7de5-47cb-acde-39073b3e508f.png">

