### PR TITLE
fix: add missing CACHE_VERSION in pod_install

### DIFF
--- a/src/commands/pod_install.yml
+++ b/src/commands/pod_install.yml
@@ -20,8 +20,8 @@ steps:
       steps:
         - restore_cache:
             keys:
-              - cache-pods-{{ checksum "<<parameters.pod_install_directory>>/Podfile.lock" }}-{{ .Environment.CACHE_VERSION }}
-              - cache-pods-
+              - {{ .Environment.CACHE_VERSION }}-cache-pods-{{ checksum "<<parameters.pod_install_directory>>/Podfile.lock" }}
+              - {{ .Environment.CACHE_VERSION }}-cache-pods
   - run:
       name: Install CocoaPods
       command: |
@@ -32,4 +32,4 @@ steps:
         - save_cache:
             paths:
               - <<parameters.pod_install_directory>>/Pods
-            key: cache-pods-{{ checksum "<<parameters.pod_install_directory>>/Podfile.lock" }}-{{ .Environment.CACHE_VERSION }}
+            key: {{ .Environment.CACHE_VERSION }}-cache-pods-{{ checksum "<<parameters.pod_install_directory>>/Podfile.lock" }}


### PR DESCRIPTION
## Description

Currently there is no way to bust the `pod` cache since it falls back to the `cache-pods-` key:

<img width="1240" alt="pods-cache" src="https://user-images.githubusercontent.com/11336/155722062-ae7a9303-f188-4117-a997-406250aeb557.png">

This PR adds the missing `CACHE_VERSION` in the fallback key.

The fallback cache is preventing the upgrade of `react-native`, due to an error with `RTC-Folly` as described in https://github.com/facebook/react-native/pull/32659. In the meantime busting the cache would be a viable workaround.

## Related

- https://github.com/facebook/react-native/pull/32659