### PR TITLE
fix: quote cache keys that start with special characters

### DIFF
--- a/src/commands/pod_install.yml
+++ b/src/commands/pod_install.yml
@@ -20,8 +20,8 @@ steps:
       steps:
         - restore_cache:
             keys:
-              - {{ .Environment.CACHE_VERSION }}-cache-pods-{{ checksum "<<parameters.pod_install_directory>>/Podfile.lock" }}
-              - {{ .Environment.CACHE_VERSION }}-cache-pods
+              - '{{ .Environment.CACHE_VERSION }}-cache-pods-{{ checksum "<<parameters.pod_install_directory>>/Podfile.lock" }}'
+              - '{{ .Environment.CACHE_VERSION }}-cache-pods'
   - run:
       name: Install CocoaPods
       command: |
@@ -32,4 +32,4 @@ steps:
         - save_cache:
             paths:
               - <<parameters.pod_install_directory>>/Pods
-            key: {{ .Environment.CACHE_VERSION }}-cache-pods-{{ checksum "<<parameters.pod_install_directory>>/Podfile.lock" }}
+            key: '{{ .Environment.CACHE_VERSION }}-cache-pods-{{ checksum "<<parameters.pod_install_directory>>/Podfile.lock" }}'


### PR DESCRIPTION
## Description

Quick follow up on #142 which [broke the build](https://app.circleci.com/pipelines/github/react-native-community/react-native-circleci-orb/306/workflows/43dc0cd5-8c99-46ea-84d4-adf41091f6d2/jobs/435).

Added single quotes around cache keys that start with special characters such as `{{`.

Fixes:

```sh
circleci config pack src/ > packed-orb.yml

Error: Failed trying to marshal the tree to YAML : yaml: line 22: did not find expected '-' indicator
```

Tested with:

```
➜  circleci config pack src > packed-orb.yml
➜  circleci orb validate packed-orb.yml
Orb at `packed-orb.yml` is valid.
```

Hopefully this does the trick. 🤞 Unfortunately I have no way to actually test it.