### PR TITLE
chore: replace legacy circleci images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           paths: .
   publish:
     docker:
-      - image: circleci/node:12
+      - image: cimg/node:12
     environment:
       - PATH: '~/bin:/opt/yarn/yarn-v1.5.1/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
     steps:

--- a/src/executors/linux_js.yml
+++ b/src/executors/linux_js.yml
@@ -8,7 +8,7 @@ parameters:
     type: string
     default: medium
 docker:
-  - image: circleci/node:<<parameters.node_version>>
+  - image: cimg/node:<<parameters.node_version>>
 resource_class: <<parameters.resource_class>>
 environment:
   - PATH: '/opt/yarn/yarn-v1.5.1/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'


### PR DESCRIPTION
CircleCI deprecated the circleci/node image (see https://circleci.com/developer/images/image/cimg/node and https://circleci.com/docs/2.0/next-gen-migration-guide/). We're getting a warning on our CircleCI instance that there are going to be brownouts soon if you're still using these images, so I'm assuming it's good for everyone to get updated.