### PR TITLE
fix!: using supported Node version with cimg/node and updating comments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           paths: .
   publish:
     docker:
-      - image: cimg/node:12
+      - image: cimg/node:12.22
     environment:
       - PATH: '~/bin:/opt/yarn/yarn-v1.5.1/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
     steps:

--- a/src/executors/linux_js.yml
+++ b/src/executors/linux_js.yml
@@ -1,8 +1,8 @@
 parameters:
   node_version:
-    description: The version of Node to use. This can be either a major version ("8"), a major and minor ("8.4"), or a fully qualified version ("8.4.1").
+    description: The version of Node to use. This can be a full SemVer point release (such as 10.16.3), or just the minor release (such as 12.6), or a version alias. See https://circleci.com/developer/images/image/cimg/node#image-tags
     type: string
-    default: '12'
+    default: '12.22'
   resource_class:
     description: Changes the resource class of the executor. Requires a support request to enable the resource_class parameter. See https://circleci.com/docs/2.0/configuration-reference/#resource_class
     type: string


### PR DESCRIPTION
BREAKING CHANGE: cimg/node doesn't support major Node version aliases the same way circleci/node did