### PR TITLE
fix: yarn build issue with cimg/node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,6 @@ jobs:
   publish:
     docker:
       - image: cimg/node:12.22
-    environment:
-      - PATH: '~/bin:/opt/yarn/yarn-v1.5.1/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
     steps:
       - attach_workspace:
           at: .

--- a/src/executors/linux_js.yml
+++ b/src/executors/linux_js.yml
@@ -10,5 +10,3 @@ parameters:
 docker:
   - image: cimg/node:<<parameters.node_version>>
 resource_class: <<parameters.resource_class>>
-environment:
-  - PATH: '/opt/yarn/yarn-v1.5.1/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'


### PR DESCRIPTION
Follow up to https://github.com/react-native-community/react-native-circleci-orb/pull/147. This removes the PATH to an old yarn version, which doesn't exist anymore with the current instance version.

This passed on our circleci instance so hopefully it's actually good now