### PR TITLE
fix: allow to use scheme with spaces and special characters

### DIFF
--- a/src/commands/ios_build.yml
+++ b/src/commands/ios_build.yml
@@ -40,7 +40,7 @@ steps:
 
   - run:
       name: Build iOS App
-      command: "export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -<<parameters.project_type>> <<parameters.project_path>> -destination 'platform=iOS Simulator,name=<<parameters.device>>' -scheme <<parameters.scheme>> -parallelizeTargets -configuration <<parameters.build_configuration>> -derivedDataPath <<parameters.derived_data_path>>  -UseModernBuildSystem=YES | xcpretty -k"
+      command: "export RCT_NO_LAUNCH_PACKAGER=true && xcodebuild -<<parameters.project_type>> <<parameters.project_path>> -destination 'platform=iOS Simulator,name=<<parameters.device>>' -scheme '<<parameters.scheme>>' -parallelizeTargets -configuration <<parameters.build_configuration>> -derivedDataPath <<parameters.derived_data_path>>  -UseModernBuildSystem=YES | xcpretty -k"
 
   - when:
       condition: <<parameters.cache>>


### PR DESCRIPTION
If scheme name has `-` build fails with the following error:
```
xcodebuild: error: Unknown build action '-'.
```
This should prevent this error from happening. Xcode allows to use those characters in scheme name. It's only bash issue.

I tried using `''` in config:
```
- rn/ios_build:
          scheme: 'Schema Name - BDD'
```
it didn't help.