### PR TITLE
Fix yarn cache key - resolves #151

### DIFF
--- a/src/commands/yarn_install.yml
+++ b/src/commands/yarn_install.yml
@@ -47,5 +47,4 @@ steps:
         - save_cache:
             paths:
               - <<parameters.cache_folder>>
-            key: |
-              yarn-cache-{{ arch }}-{{ checksum "~/.tmp/checksumfiles/package.json" }}-{{ checksum "~/.tmp/checksumfiles/yarn.lock" }}-{{ .Environment.CACHE_VERSION }}
+            key: yarn-cache-{{ arch }}-{{ checksum "~/.tmp/checksumfiles/package.json" }}-{{ checksum "~/.tmp/checksumfiles/yarn.lock" }}-{{ .Environment.CACHE_VERSION }}


### PR DESCRIPTION
Circle ci doesn't allow new line in the cache key anymore. This fixed `unexpected storage error` in my build.