### PR TITLE
fix: 'an unexpected storage error occurred' on multiline keys

### DIFF
--- a/src/commands/setup_macos_executor.yml
+++ b/src/commands/setup_macos_executor.yml
@@ -30,8 +30,7 @@ steps:
       condition: <<parameters.homebrew_cache>>
       steps:
         - restore_cache:
-            key: |
-              brew-cache-{{ arch }}-{{ .Environment.CACHE_VERSION }}
+            key: brew-cache-{{ arch }}-{{ .Environment.CACHE_VERSION }}
 
   - run:
       name: Install node@<<parameters.node_version>>
@@ -72,5 +71,4 @@ steps:
         - save_cache:
             paths:
               - ~/Library/Caches/Homebrew
-            key: |
-              brew-cache-{{ arch }}-{{ .Environment.CACHE_VERSION }}
+            key: brew-cache-{{ arch }}-{{ .Environment.CACHE_VERSION }}

--- a/src/commands/yarn_install.yml
+++ b/src/commands/yarn_install.yml
@@ -47,5 +47,4 @@ steps:
         - save_cache:
             paths:
               - <<parameters.cache_folder>>
-            key: |
-              yarn-cache-{{ arch }}-{{ checksum "~/.tmp/checksumfiles/package.json" }}-{{ checksum "~/.tmp/checksumfiles/yarn.lock" }}-{{ .Environment.CACHE_VERSION }}
+            key: yarn-cache-{{ arch }}-{{ checksum "~/.tmp/checksumfiles/package.json" }}-{{ checksum "~/.tmp/checksumfiles/yarn.lock" }}-{{ .Environment.CACHE_VERSION }}


### PR DESCRIPTION
Due to https://discuss.circleci.com/t/error-uploading-archive-cache-at-storage-caches/44222/3 the cache wasn't used on running CircleCI, but rather received an error as mentioned in https://github.com/react-native-community/react-native-circleci-orb/issues/151
The `key: |` was used in yarn + brew's cache.