### PR TITLE
feat(node): bump from node 12 to node 16 default

### DIFF
--- a/src/executors/linux_js.yml
+++ b/src/executors/linux_js.yml
@@ -1,8 +1,8 @@
 parameters:
   node_version:
-    description: The version of Node to use. This can be a full SemVer point release (such as 10.16.3), or just the minor release (such as 12.6), or a version alias. See https://circleci.com/developer/images/image/cimg/node#image-tags
+    description: The version of Node to use. This can be a full SemVer point release (such as 16.15.2), or just the minor release (such as 18.2), or a version alias. See https://circleci.com/developer/images/image/cimg/node#image-tags
     type: string
-    default: '12.22'
+    default: '16.15'
   resource_class:
     description: Changes the resource class of the executor. Requires a support request to enable the resource_class parameter. See https://circleci.com/docs/2.0/configuration-reference/#resource_class
     type: string


### PR DESCRIPTION

node 12 is out of support I think (?), and node v16 is known to work with react-native, I *hope* it's mostly backwards compatible and this is okay?

Either way, it was needed as an override for the semantic-release package which just dropped support for 12 and works with 16 now - https://github.com/react-native-share/react-native-share/pull/1218

Not sure if this is a breaking change or not, as I'm unsure of backwards compatibility status