### PR TITLE
Update README to reference the latest orb version

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ version: 2.1
 
 # Make sure you use the latest version of the Orb!
 orbs:
-  rn: react-native-community/react-native@2.0.1
+  rn: react-native-community/react-native@7.1.0
 
 # Custom jobs which are not part of the Orb
 jobs:


### PR DESCRIPTION
Hi!

Having just looked into this repository for some CircleCI configuration, and (despite the helpful comment one line above) made the facepalm-worthy mistake of _not_ checking the latest version, I wanted to propose that the README be updated to reference the latest version of the orb. 

Thanks!