### PR TITLE
Update XCode version to 12.5.1

### DIFF
--- a/src/executors/macos.yml
+++ b/src/executors/macos.yml
@@ -2,7 +2,7 @@ parameters:
   xcode_version:
     description: The version of Xcode to use. See here for the list of supported versions https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
     type: string
-    default: "12.4.0"
+    default: "12.5.1"
   resource_class:
     description: Changes the resource class of the executor. Requires a support request to enable the resource_class parameter. See https://circleci.com/docs/2.0/configuration-reference/#resource_class
     type: string

--- a/src/jobs/android_test.yml
+++ b/src/jobs/android_test.yml
@@ -77,7 +77,7 @@ parameters:
   xcode_version:
     description: The version of Xcode to use. See here for the list of supported versions https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
     type: string
-    default: "12.4.0"
+    default: "12.5.1"
   resource_class:
     description: Changes the resource class of the executor. Requires a support request to enable the resource_class parameter. See https://circleci.com/docs/2.0/configuration-reference/#resource_class
     type: string

--- a/src/jobs/ios_build.yml
+++ b/src/jobs/ios_build.yml
@@ -82,7 +82,7 @@ parameters:
   xcode_version:
     description: The version of Xcode to use. See here for the list of supported versions https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
     type: string
-    default: "12.4.0"
+    default: "12.5.1"
   resource_class:
     description: Changes the resource class of the executor. Requires a support request to enable the resource_class parameter. See https://circleci.com/docs/2.0/configuration-reference/#resource_class
     type: string

--- a/src/jobs/ios_build_and_test.yml
+++ b/src/jobs/ios_build_and_test.yml
@@ -96,7 +96,7 @@ parameters:
   xcode_version:
     description: The version of Xcode to use. See here for the list of supported versions https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
     type: string
-    default: "12.4.0"
+    default: "12.5.1"
   resource_class:
     description: Changes the resource class of the executor. Requires a support request to enable the resource_class parameter. See https://circleci.com/docs/2.0/configuration-reference/#resource_class
     type: string


### PR DESCRIPTION
Xcode 12.4.0 has been removed from CircleCI

When we try to build with this orb we get the following error at the beginning
```
Build-agent version 1.0.134103-8a9e13ee (2022-08-02T13:24:16+0000)
Creating a dedicated VM with xcode:12.4.0 image
failed to create host: Image xcode:12.4.0 is not supported

failed to create host: Image xcode:12.4.0 is not supported
```

Sources:
https://discuss.circleci.com/t/xcode-image-deprecation/44294
https://circleci.com/docs/testing-ios#supported-xcode-versions