### PR TITLE
feat: allow specifying build image version for android build & executor

### DIFF
--- a/src/executors/linux_android.yml
+++ b/src/executors/linux_android.yml
@@ -7,12 +7,16 @@ parameters:
     description: Gradle command options. Note that setting this will override the default options so you might need to supply those as well.
     type: string
     default: '-Xmx2014m -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-XX:+UnlockExperimentalVMOptions -XX:+HeapDumpOnOutOfMemoryError"'
+  build_image_version:
+    description: React Native Android build image version. For available veresions, see https://hub.docker.com/r/reactnativecommunity/react-native-android/tags
+    type: string
+    default: 5.1
   resource_class:
     description: Changes the resource class of the executor. Requires a support request to enable the resource_class parameter. See https://circleci.com/docs/2.0/configuration-reference/#resource_class
     type: string
     default: medium
 docker:
-  - image: reactnativecommunity/react-native-android:5.1
+  - image: reactnativecommunity/react-native-android:<<parameters.build_image_version>>
 resource_class: <<parameters.resource_class>>
 environment:
   - _JAVA_OPTIONS: <<parameters.java_options>>

--- a/src/jobs/android_build.yml
+++ b/src/jobs/android_build.yml
@@ -55,6 +55,10 @@ parameters:
     description: Gradle command options. Note that setting this will override the default options so you might need to supply those as well.
     type: string
     default: '-Xmx2014m -Dorg.gradle.daemon=false -Dorg.gradle.jvmargs="-XX:+UnlockExperimentalVMOptions -XX:+HeapDumpOnOutOfMemoryError"'
+  build_image_version:
+    description: React Native Android build image version. For available veresions, see https://hub.docker.com/r/reactnativecommunity/react-native-android/tags
+    type: string
+    default: 5.1
   resource_class:
     description: Changes the resource class of the executor. Requires a support request to enable the resource_class parameter. See https://circleci.com/docs/2.0/configuration-reference/#resource_class
     type: string
@@ -64,6 +68,7 @@ executor:
   name: linux_android
   java_options: <<parameters.java_options>>
   gradle_options: <<parameters.gradle_options>>
+  build_image_version: <<parameters.build_image_version>>
   resource_class: <<parameters.resource_class>>
 
 steps:


### PR DESCRIPTION
Newer versions are needed for e.g. NodeJS updates.
Not changing the default to avoid breaking any builds.