### PR TITLE
fix: yaml parsing build_image_version default as double

### DIFF
--- a/src/executors/linux_android.yml
+++ b/src/executors/linux_android.yml
@@ -10,7 +10,7 @@ parameters:
   build_image_version:
     description: React Native Android build image version. For available veresions, see https://hub.docker.com/r/reactnativecommunity/react-native-android/tags
     type: string
-    default: 5.1
+    default: '5.1'
   resource_class:
     description: Changes the resource class of the executor. Requires a support request to enable the resource_class parameter. See https://circleci.com/docs/2.0/configuration-reference/#resource_class
     type: string


### PR DESCRIPTION
This time I actually ran `./scripts/pack.sh && circleci orb validate packed-orb.yml`. Would be nice if CI did that on PRs