### PR TITLE
chore: fix orb badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,5 +145,5 @@ This is what the final workflow will look like:
 ## License
 The Orb is released under the MIT license. For more information see [`LICENSE`](https://github.com/react-native-community/react-native-circleci-orb/blob/master/LICENSE).
 
-[orb-version-badge]:https://img.shields.io/endpoint.svg?url=https://badges.circleci.io/orb/react-native-community/react-native&style=flat-square
+[orb-version-badge]:https://badges.circleci.com/orbs/react-native-community/react-native.svg
 [orb-page]:https://circleci.com/orbs/registry/orb/react-native-community/react-native


### PR DESCRIPTION
Fix the orb badge in the README.

Going from this:

<img width="445" alt="failing-badge" src="https://github.com/react-native-community/react-native-circleci-orb/assets/11336/99724714-8465-4dee-8fea-b7fd34b7c674">

To this:

<img width="430" alt="working-badge" src="https://github.com/react-native-community/react-native-circleci-orb/assets/11336/16e3ece6-10f6-4bba-9d10-41e11f5ec63a">

## Reference

* https://discuss.circleci.com/t/new-orb-version-badge-endpoint/39515