### PR TITLE
chore: rename master branch to main

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -38,7 +38,7 @@ workflows:
             - command-test
           filters:
             branches:
-              only: master
+              only: main
 
       - orb-tools/pack:
           filters: *release-filters

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ This is what the final workflow will look like:
 ![Example React Native CircleCI Orb Workflow](.github/example_workflow.png)
 
 ## License
-The Orb is released under the MIT license. For more information see [`LICENSE`](https://github.com/react-native-community/react-native-circleci-orb/blob/master/LICENSE).
+The Orb is released under the MIT license. For more information see [`LICENSE`](https://github.com/react-native-community/react-native-circleci-orb/blob/main/LICENSE).
 
 [orb-version-badge]:https://badges.circleci.com/orbs/react-native-community/react-native.svg
 [orb-page]:https://circleci.com/orbs/registry/orb/react-native-community/react-native


### PR DESCRIPTION
Rename the `master` branch to `main`.

Needs to be merged after the default branch is changed in the settings:

<img width="660" alt="default-branch" src="https://github.com/react-native-community/react-native-circleci-orb/assets/11336/f7a4047a-62a5-4574-a9da-50a1500700aa">
