### PR TITLE
Specify main branch for semantic release

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,4 +1,5 @@
 {
+  "branches": ["main"],
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
Quick follow up to #188.

Fixes the [following error](https://app.circleci.com/pipelines/github/react-native-community/react-native-circleci-orb/394/workflows/deec3930-bd2a-4059-a063-d862d66e9002/jobs/770/parallel-runs/0/steps/0-108) in CircleCI:

<img width="987" alt="branch" src="https://github.com/react-native-community/react-native-circleci-orb/assets/11336/395b410b-60c0-4adb-aab0-ea7f2ee56394">
