### PR TITLE
Resource Class Parameter and MacOS Executor

### DIFF
--- a/src/executors/linux_android.yml
+++ b/src/executors/linux_android.yml
@@ -12,7 +12,7 @@ parameters:
     type: string
     default: '5.1'
   resource_class:
-    description: Changes the resource class of the executor. Requires a support request to enable the resource_class parameter. See https://circleci.com/docs/2.0/configuration-reference/#resource_class
+    description: You can use whatever resource class your plan has access to. https://circleci.com/product/features/resource-classes/
     type: string
     default: medium
 docker:

--- a/src/executors/linux_js.yml
+++ b/src/executors/linux_js.yml
@@ -4,7 +4,7 @@ parameters:
     type: string
     default: '16.15'
   resource_class:
-    description: Changes the resource class of the executor. Requires a support request to enable the resource_class parameter. See https://circleci.com/docs/2.0/configuration-reference/#resource_class
+    description: You can use whatever resource class your plan has access to. https://circleci.com/product/features/resource-classes/
     type: string
     default: medium
 docker:

--- a/src/executors/macos.yml
+++ b/src/executors/macos.yml
@@ -4,9 +4,9 @@ parameters:
     type: string
     default: "12.5.1"
   resource_class:
-    description: Changes the resource class of the executor. Requires a support request to enable the resource_class parameter. See https://circleci.com/docs/2.0/configuration-reference/#resource_class
+    description: You can use whatever resource class your plan has access to. https://circleci.com/product/features/resource-classes/
     type: string
-    default: medium
+    default: macos.x86.medium.gen2
 macos:
   xcode: <<parameters.xcode_version>>
 resource_class: <<parameters.resource_class>>

--- a/src/jobs/android_build.yml
+++ b/src/jobs/android_build.yml
@@ -60,7 +60,7 @@ parameters:
     type: string
     default: '5.1'
   resource_class:
-    description: Changes the resource class of the executor. Requires a support request to enable the resource_class parameter. See https://circleci.com/docs/2.0/configuration-reference/#resource_class
+    description: You can use whatever resource class your plan has access to. https://circleci.com/product/features/resource-classes/
     type: string
     default: medium
 

--- a/src/jobs/android_test.yml
+++ b/src/jobs/android_test.yml
@@ -79,7 +79,7 @@ parameters:
     type: string
     default: "12.5.1"
   resource_class:
-    description: Changes the resource class of the executor. Requires a support request to enable the resource_class parameter. See https://circleci.com/docs/2.0/configuration-reference/#resource_class
+    description: You can use whatever resource class your plan has access to. https://circleci.com/product/features/resource-classes/
     type: string
     default: medium
 

--- a/src/jobs/ios_build.yml
+++ b/src/jobs/ios_build.yml
@@ -84,7 +84,7 @@ parameters:
     type: string
     default: "12.5.1"
   resource_class:
-    description: Changes the resource class of the executor. Requires a support request to enable the resource_class parameter. See https://circleci.com/docs/2.0/configuration-reference/#resource_class
+    description: You can use whatever resource class your plan has access to. https://circleci.com/product/features/resource-classes/
     type: string
     default: medium
 

--- a/src/jobs/ios_build_and_test.yml
+++ b/src/jobs/ios_build_and_test.yml
@@ -98,7 +98,7 @@ parameters:
     type: string
     default: "12.5.1"
   resource_class:
-    description: Changes the resource class of the executor. Requires a support request to enable the resource_class parameter. See https://circleci.com/docs/2.0/configuration-reference/#resource_class
+    description: You can use whatever resource class your plan has access to. https://circleci.com/product/features/resource-classes/
     type: string
     default: medium
 


### PR DESCRIPTION
CircleCI Support does not need to enable the `resource_class` parameter as everyone has access to the resource class that their plan allows.